### PR TITLE
フラッシュメッセージを設定

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,8 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 @import '@fortawesome/fontawesome-free/scss/fontawesome';
 @import '@fortawesome/fontawesome-free/scss/regular';
 
+@import 'toastr/build/toastr.min';
+
 @import url('https://fonts.googleapis.com/css2?family=Shippori+Mincho:wght@500&family=WindSong:wght@500&display=swap');
 
 // 全体

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :success, :info, :warning, :danger
+
   protected
 
   def not_authenticated

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,14 +4,15 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to root_path
+      redirect_back_or_to root_path, success: 'ログインしました。'
     else
+      flash.now[:danger] = 'ログインに失敗しました。'
       render :new
     end
   end
 
   def destroy
     logout
-    redirect_to root_path
+    redirect_to root_path, success: 'ログアウトしました。'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,8 +8,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path
+      redirect_to login_path, success: '会員登録が完了しました。'
     else
+      flash.now[:danger] = '会員登録に失敗しました。'
       render :new
     end
   end
@@ -23,8 +24,9 @@ class UsersController < ApplicationController
   def update
     @user = current_user
     if @user.update(user_params)
-      redirect_to '/mypage'
+      redirect_to '/mypage', success: '登録情報を更新しました。'
     else
+      flash.now[:danger] = '登録情報の更新に失敗しました。'
       render :edit
     end
   end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,3 +6,5 @@ require('jquery');
 
 import 'bootstrap/dist/js/bootstrap';
 import '@fortawesome/fontawesome-free/js/all';
+import toastr from 'toastr';
+window.toastr = toastr;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,12 +11,10 @@
     <header>
       <%= render 'shared/header'%>
     </header>
-    <script type="text/javascript">
-      toastr.success("hello")
-    </script>
     <%= yield %>
     <footer>
       <%= render 'shared/footer'%>
     </footer>
+    <%= render 'shared/flash_message' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,9 @@
     <header>
       <%= render 'shared/header'%>
     </header>
+    <script type="text/javascript">
+      toastr.success("hello")
+    </script>
     <%= yield %>
     <footer>
       <%= render 'shared/footer'%>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,9 @@
+<% if flash.any? %>
+  <script type="text/javascript">
+    <% flash.each do |key, value| %>
+      <% key = "success" if key == "success" %>
+      <% key = "error" if key == "danger" %>
+      toastr['<%= key %>']('<%= value %>');
+    <% end %>
+  </script>
+<% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,6 +7,8 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.precompile += ['node_modules/toastr/build/toastr.min.js']
+Rails.application.config.assets.precompile += ['node_modules/toastr/build/toastr.min.css']
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bootstrap": "~4.5.1",
     "jquery": "^3.6.0",
     "popper.js": "^1.16.1",
+    "toastr": "^2.1.4",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",


### PR DESCRIPTION
## Issue 番号

Closes #23 

## 概要

- yarn で `toastr`をインストールし設定
- フラッシュメッセージが表示されるよう`aplication.htm.erbl`にscriptの記述を追加
- 各コントローラーのメッセージを修正

## 参考資料


## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
- [ ] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
`toastr`でのフラッシュメッセージは表画面のみ。
各コントローラーを作成次第、メッセージを各アクションに設定していく。
