### PR TITLE
Home画面にFadeinのエフェクトを追加 

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,5 +7,6 @@ require('slick.js');
 
 import 'bootstrap/dist/js/bootstrap';
 import '@fortawesome/fontawesome-free/js/all';
+import './fadein';
 import toastr from 'toastr';
 window.toastr = toastr;

--- a/app/javascript/packs/fadein.js
+++ b/app/javascript/packs/fadein.js
@@ -1,0 +1,12 @@
+$(function () {
+  $(window).scroll(function () {
+    $('.fadein').each(function () {
+      var elemPos = $(this).offset().top;
+      var scroll = $(window).scrollTop();
+      var windowHeight = $(window).height();
+      if (scroll > elemPos - windowHeight + 200) {
+        $(this).addClass('scrollin');
+      }
+    });
+  });
+});

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -36,17 +36,3 @@
     </div>
   </div>
 </center>
-<script>
-  $(function(){
-  	$(window).scroll(function (){
-  		$('.fadein').each(function(){
-  			var elemPos = $(this).offset().top;
-  			var scroll = $(window).scrollTop();
-  			var windowHeight = $(window).height();
-  			if (scroll > elemPos - windowHeight + 200){
-  				$(this).addClass('scrollin');
-  			}
-  		});
-  	});
-  });
-</script>


### PR DESCRIPTION
## Issue 番号

Closes #28 

## 概要

- Home画面Aboutがスクロール時にフェイドイン
- CSSの設定
- Javascriptの設定

## 参考資料

マークダウン記法のリンクを用いて記載すること

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
