### PR TITLE
RSpec[Userモデルスペック]を作成

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,8 @@ class User < ApplicationRecord
   VALID_PHONE_REGEX = /\A\d{10,11}\z/.freeze
 
   validates :name, presence: true, length: { maximum: 20 }
-  validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX, message: 'は正しいメールアドレスを入力してください' }, length: { maximum: 256 }
-  validates :phonenumber, presence: true, uniqueness: true, format: { with: VALID_PHONE_REGEX, message: 'は正しい電話番号を入力してください' }, length: { in: 10..11 }
+  validates :email, presence: true, uniqueness: { case_sensitive: true }, format: { with: VALID_EMAIL_REGEX, message: 'は正しいメールアドレスを入力してください' }, length: { maximum: 256 }
+  validates :phonenumber, presence: true, uniqueness: { case_sensitive: false }, format: { with: VALID_PHONE_REGEX, message: 'は正しい電話番号を入力してください' }, length: { in: 10..11 }
   validates :password, format: { with: VALID_PASSWORD_REGEX, message: 'は半角英字・数字を混ぜて8文字以上36文字以内にしてください' }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,5 +6,17 @@ RSpec.describe User, type: :model do
       user = build(:user)
       expect(user).to be_valid
     end
+
+    it 'ユーザー名がない場合、無効' do
+      user = build(:user, name: nil)
+      user.valid?
+      expect(user.errors[:name]).to include('を入力してください')
+    end
+
+    it 'ユーザー名が21文字以上、無効' do
+      user = build(:user, name: 'a' * 21)
+      user.valid?
+      expect(user.errors[:name]).to include('は20文字以内で入力してください')
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe User, type: :model do
       expect(second_user.errors[:email]).to include('はすでに存在します')
     end
 
-    it '指定formatに合わないemailを許容しないこと' do
+    it 'メールアドレスが指定formatに合わない場合、無効' do
       invalid_emails = %w[user@foo,com user_at_foo.org example.user@foo.foo@bar_baz.com foo@bar+baz.com foo@bar..com]
-      invalid_emails.each do |_invalid_email|
-        expect(user.errors[:email]).to be_invalid
+      invalid_emails.each do |invalid_email|
+        expect(build(:user, email: invalid_email)).to be_invalid
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -71,15 +71,15 @@ RSpec.describe User, type: :model do
     end
 
     it '電話番号が指定formatに合わない場合、無効' do
-      invalid_phonenumber = %w[００００００００００ 0000000000a]
-      invalid_phonenumber.each do |invalid_phonenumber|
+      invalid_phonenumbers = %w[００００００００００ 0000000000a]
+      invalid_phonenumbers.each do |invalid_phonenumber|
         expect(build(:user, phonenumber: invalid_phonenumber)).to be_invalid
       end
     end
 
     it '電話番号が指定formatに合わない場合、無効' do
-      invalid_password = %w[Aaaa0000 0000000000 aaaaaaaa AAAAAAAA aaaa0000 AAAA0000 AAAAaaaa]
-      invalid_password.each do |invalid_password|
+      invalid_passwords = %w[Aaaa0000 0000000000 aaaaaaaa AAAAAAAA aaaa0000 AAAA0000 AAAAaaaa]
+      invalid_passwords.each do |invalid_password|
         expect(build(:user, password: invalid_password)).to be_invalid
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validation' do
+    it 'ユーザー名、メールアドレス、電話番号、パスワードがある場合、有効' do
+      user = build(:user)
+      expect(user).to be_valid
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,5 +18,31 @@ RSpec.describe User, type: :model do
       user.valid?
       expect(user.errors[:name]).to include('は20文字以内で入力してください')
     end
+
+    it 'メールアドレスがない場合、無効' do
+      user = build(:user, email: nil)
+      user.valid?
+      expect(user.errors[:email]).to include('を入力してください')
+    end
+
+    it 'メールアドレスが256文字以上、無効' do
+      user = build(:user, email: 'a' * 253 << '@a.a')
+      user.valid?
+      expect(user.errors[:email]).to include('は256文字以内で入力してください')
+    end
+
+    it 'メールアドレスが重複している場合、無効' do
+      first_user = create(:user, email: 'test@example.com')
+      second_user = build(:user, email: first_user.email)
+      second_user.valid?
+      expect(second_user.errors[:email]).to include('はすでに存在します')
+    end
+
+    it '指定formatに合わないemailを許容しないこと' do
+      invalid_emails = %w[user@foo,com user_at_foo.org example.user@foo.foo@bar_baz.com foo@bar+baz.com foo@bar..com]
+      invalid_emails.each do |_invalid_email|
+        expect(user.errors[:email]).to be_invalid
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,5 +76,18 @@ RSpec.describe User, type: :model do
         expect(build(:user, phonenumber: invalid_phonenumber)).to be_invalid
       end
     end
+
+    it '電話番号が指定formatに合わない場合、無効' do
+      invalid_password = %w[Aaaa0000 0000000000 aaaaaaaa AAAAAAAA aaaa0000 AAAA0000 AAAAaaaa]
+      invalid_password.each do |invalid_password|
+        expect(build(:user, password: invalid_password)).to be_invalid
+      end
+    end
+
+    it 'パスワード確認がない場合、無効' do
+      user = build(:user, password_confirmation: nil)
+      user.valid?
+      expect(user.errors[:password_confirmation]).to include('を入力してください')
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,5 +44,37 @@ RSpec.describe User, type: :model do
         expect(build(:user, email: invalid_email)).to be_invalid
       end
     end
+
+    it '電話番号がない場合、無効' do
+      user = build(:user, phonenumber: nil)
+      user.valid?
+      expect(user.errors[:phonenumber]).to include('を入力してください')
+    end
+
+    it '電話番号が9文字以下、無効' do
+      user = build(:user, phonenumber: '0' * 9)
+      user.valid?
+      expect(user.errors[:phonenumber]).to include('は10文字以上で入力してください')
+    end
+
+    it '電話番号が12文字以上、無効' do
+      user = build(:user, phonenumber: '0' * 12)
+      user.valid?
+      expect(user.errors[:phonenumber]).to include('は11文字以内で入力してください')
+    end
+
+    it '電話番号が重複している場合、無効' do
+      first_user = create(:user, phonenumber: '00000000000')
+      second_user = build(:user, phonenumber: first_user.phonenumber)
+      second_user.valid?
+      expect(second_user.errors[:phonenumber]).to include('はすでに存在します')
+    end
+
+    it '電話番号が指定formatに合わない場合、無効' do
+      invalid_phonenumber = %w[００００００００００ 0000000000a]
+      invalid_phonenumber.each do |invalid_phonenumber|
+        expect(build(:user, phonenumber: invalid_phonenumber)).to be_invalid
+      end
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -61,4 +61,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    
+  end
+end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :user do
-    
+    sequence(:name, 'name_1')
+    sequence(:email) { |n| "user_#{n}@example.com" }
+    sequence(:phonenumber) { |n| "0900000000#{n}" }
+    password { 'pass1111' }
+    password_confirmation { 'pass1111' }
   end
 end


### PR DESCRIPTION
## Issue 番号

Closes #44 

## 概要

- Userモデルのモデルスペックを作成
- バリデーション`uniqueness`に大文字小文字の区別を追加


## 参考資料

[モデルスペック参考](https://qiita.com/Goi350ml/items/7dac5bd2d3d522466d94)

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
- [ ] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
