### PR TITLE
RSpec[Usersコントローラーシステムスペック]を作成

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe User, type: :model do
     end
 
     it 'メールアドレスが指定formatに合わない場合、無効' do
-      invalid_emails = %w[user@foo,com user_at_foo.org example.user@foo.foo@bar_baz.com foo@bar+baz.com foo@bar..com]
+      invalid_emails = %w[user@foo,com user_at_foo.org example.user@foo.foo@bar_baz.com foo@bar+baz.com]
       invalid_emails.each do |invalid_email|
         expect(build(:user, email: invalid_email)).to be_invalid
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -62,4 +62,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include LoginModule
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,8 +44,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
 
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
@@ -53,43 +53,42 @@ RSpec.configure do |config|
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,14 +46,13 @@ RSpec.configure do |config|
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
-=begin
+
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
-
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome
+  end
+end

--- a/spec/support/login_module.rb
+++ b/spec/support/login_module.rb
@@ -1,10 +1,8 @@
 module LoginModule
   def login(user)
     visit login_path
-    fill_in 'Name', with: 'user'
-    fill_in 'Email', with: user.email
-    fill_in 'Phonenumber', with: user.phonenumber
-    fill_in 'Password', with: 'pass1111'
-    click_button 'Login'
+    fill_in 'email', with: user.email
+    fill_in 'password', with: 'pass1111'
+    click_button 'ログイン'
   end
 end

--- a/spec/support/login_module.rb
+++ b/spec/support/login_module.rb
@@ -1,0 +1,10 @@
+module LoginModule
+  def login(user)
+    visit login_path
+    fill_in 'Name', with: 'user'
+    fill_in 'Email', with: user.email
+    fill_in 'Phonenumber', with: user.phonenumber
+    fill_in 'Password', with: 'pass1111'
+    click_button 'Login'
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe User, type: :system do
           fill_in 'Password', with: 'pass1111'
           fill_in 'パスワード(確認用)', with: 'pass1111'
           click_button '規約に同意して次へ'
+          expect(page).to have_content '会員登録が完了しました。'
           expect(current_path).to eq login_path
         end
       end
@@ -27,6 +28,7 @@ RSpec.describe User, type: :system do
           fill_in 'Password', with: 'pass1111'
           fill_in 'パスワード(確認用)', with: 'pass1111'
           click_button '規約に同意して次へ'
+          expect(page).to have_content '会員登録に失敗しました。'
           expect(current_path).to eq users_path
         end
       end
@@ -50,6 +52,134 @@ RSpec.describe User, type: :system do
     context 'ログインしていない状態' do
       it 'マイページへのアクセスが失敗する' do
         visit '/mypage'
+        expect(current_path).to eq root_path
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    before { login(user) }
+
+    describe 'ユーザー編集' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの編集が成功する' do
+          visit '/mypage/edit'
+          fill_in 'Name', with: 'user_1'
+          fill_in 'Email', with: 'update@example.com'
+          fill_in 'Phonenumber', with: '09000000000'
+          click_button '更新'
+          expect(page).to have_content '登録情報を更新しました。'
+          expect(current_path).to eq '/mypage'
+        end
+      end
+    end
+
+    context '名前が未入力' do
+      it 'ユーザーの編集が失敗する' do
+        visit '/mypage/edit'
+        fill_in 'Name', with: ''
+        fill_in 'Email', with: 'update@example.com'
+        fill_in 'Phonenumber', with: '09000000000'
+        click_button '更新'
+        expect(current_path).to eq '/mypage/edit'
+      end
+    end
+
+    context 'メールアドレスが未入力' do
+      it 'ユーザーの編集が失敗する' do
+        visit '/mypage/edit'
+        fill_in 'Name', with: 'user_1'
+        fill_in 'Email', with: ''
+        fill_in 'Phonenumber', with: '09000000000'
+        click_button '更新'
+        expect(current_path).to eq '/mypage/edit'
+      end
+    end
+
+    context '電話番号が未入力' do
+      it 'ユーザーの編集が失敗する' do
+        visit '/mypage/edit'
+        fill_in 'Name', with: 'user_1'
+        fill_in 'Email', with: 'update@example.com'
+        fill_in 'Phonenumber', with: ''
+        click_button '更新'
+        expect(current_path).to eq '/mypage/edit'
+      end
+    end
+
+    context '名前が21文字以上' do
+      it 'ユーザーの編集が失敗する' do
+        visit '/mypage/edit'
+        fill_in 'Name', with: 'a' * 21
+        fill_in 'Email', with: 'update@example.com'
+        fill_in 'Phonenumber', with: '09000000000'
+        click_button '更新'
+        expect(current_path).to eq '/mypage/edit'
+      end
+    end
+
+    context 'メールアドレスが256文字以上' do
+      it 'ユーザーの編集が失敗する' do
+        visit '/mypage/edit'
+        fill_in 'Name', with: 'user_1'
+        fill_in 'Email', with: 'a' * 253 << '@a.a'
+        fill_in 'Phonenumber', with: '09000000000'
+        click_button '更新'
+        expect(current_path).to eq '/mypage/edit'
+      end
+    end
+
+    context '電話番号が9文字以下' do
+      it 'ユーザーの編集が失敗する' do
+        visit '/mypage/edit'
+        fill_in 'Name', with: 'user_1'
+        fill_in 'Email', with: 'update@example.com'
+        fill_in 'Phonenumber', with: '090000000'
+        click_button '更新'
+        expect(current_path).to eq '/mypage/edit'
+      end
+    end
+
+    context '電話番号が12文字以上' do
+      it 'ユーザーの編集が失敗する' do
+        visit '/mypage/edit'
+        fill_in 'Name', with: 'user_1'
+        fill_in 'Email', with: 'update@example.com'
+        fill_in 'Phonenumber', with: '090000000000'
+        click_button '更新'
+        expect(current_path).to eq '/mypage/edit'
+      end
+    end
+
+    context '登録済のメールアドレスを使用' do
+      it 'ユーザーの編集が失敗する' do
+        visit '/mypage/edit'
+        other_user = create(:user)
+        fill_in 'Name', with: 'user_1'
+        fill_in 'Email', with: other_user.email
+        fill_in 'Phonenumber', with: '090000000000'
+        click_button '更新'
+        expect(current_path).to eq '/mypage/edit'
+      end
+    end
+
+    context '登録済の電話番号を使用' do
+      it 'ユーザーの編集が失敗する' do
+        visit '/mypage/edit'
+        other_user = create(:user)
+        fill_in 'Name', with: 'user_1'
+        fill_in 'Email', with: 'update@example.com'
+        fill_in 'Phonenumber', with: other_user.phonenumber
+        click_button '更新'
+        expect(current_path).to eq '/mypage/edit'
+      end
+    end
+
+    context 'ログアウトボタンをクリック' do
+      it 'ログアウト処理が成功する' do
+        visit '/mypage'
+        click_link 'ログアウト'
+        expect(page).to have_content 'ログアウトしました。'
         expect(current_path).to eq root_path
       end
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,9 +1,48 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :system do
-  before do
-    driven_by(:rack_test)
-  end
+  let(:user) { create(:user) }
 
-  pending "add some scenarios (or delete) #{__FILE__}"
+  describe 'ログイン前' do
+    describe 'ユーザー新規登録' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの新規作成が成功する' do
+          visit new_user_path
+          fill_in 'Name', with: 'test'
+          fill_in 'Email', with: 'email@example.com'
+          fill_in 'Phonenumber', with: '00000000000'
+          fill_in 'Password', with: 'pass1111'
+          fill_in 'パスワード(確認用)', with: 'pass1111'
+          click_button '規約に同意して次へ'
+          expect(current_path).to eq login_path
+        end
+      end
+      context '登録済のメールアドレスを使用' do
+        it 'ユーザーの新規作成が失敗する' do
+          existed_user = create(:user)
+          visit new_user_path
+          fill_in 'Name', with: 'test1'
+          fill_in 'Email', with: existed_user.email
+          fill_in 'Phonenumber', with: '0000000000'
+          fill_in 'Password', with: 'pass1111'
+          fill_in 'パスワード(確認用)', with: 'pass1111'
+          click_button '規約に同意して次へ'
+          expect(current_path).to eq users_path
+        end
+      end
+      context '登録済の電話番号を使用' do
+        it 'ユーザーの新規作成が失敗する' do
+          existed_user = create(:user)
+          visit new_user_path
+          fill_in 'Name', with: 'test1'
+          fill_in 'Email', with: 'email@example.com'
+          fill_in 'Phonenumber', with: existed_user.phonenumber
+          fill_in 'Password', with: 'pass1111'
+          fill_in 'パスワード(確認用)', with: 'pass1111'
+          click_button '規約に同意して次へ'
+          expect(current_path).to eq users_path
+        end
+      end
+    end
+  end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -45,4 +45,13 @@ RSpec.describe User, type: :system do
       end
     end
   end
+
+  describe 'マイページ' do
+    context 'ログインしていない状態' do
+      it 'マイページへのアクセスが失敗する' do
+        visit '/mypage'
+        expect(current_path).to eq root_path
+      end
+    end
+  end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :user do
     sequence(:name, 'name_1')
     sequence(:email) { |n| "user_#{n}@example.com" }
-    sequence(:phonenumber) { |n| "0900000000#{n}" }
+    sequence(:phonenumber) { |n| "090000000#{n}" }
     password { 'pass1111' }
     password_confirmation { 'pass1111' }
   end


### PR DESCRIPTION
## Issue 番号

Closes #47

## 概要

- Usersコントローラーシステムスペックを作成
- 特定のテストケースのみ実行できるように設定
- suportファイルのmoduleを読み込む設定を追加

## 参考資料


## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
