### PR TITLE
Userの管理者画面を作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'carrierwave'
 gem 'kaminari'
 gem 'enum_help'
 gem 'rails-i18n'
+gem 'ransack'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,10 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.6)
+    ransack (2.4.2)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
+      i18n
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -354,6 +358,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.7)
   rails-i18n
+  ransack
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,2 @@
+class Admin::UsersController < ApplicationController
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UsersController < Admin::BaseController
-  before_action :set_user, only: %i[show edit update]
+  before_action :set_user, only: %i[show edit update destroy]
 
   def index
     @users = User.all.order(created_at: :desc)
@@ -16,6 +16,11 @@ class Admin::UsersController < Admin::BaseController
       flash.now['danger'] = 'アカウント情報の変更に失敗しました'
       render :edit
     end
+  end
+
+  def destroy
+    @user.destroy!
+    redirect_to admin_users_path, success: 'アカウントを削除しました'
   end
 
   private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,9 +1,11 @@
 class Admin::UsersController < Admin::BaseController
-  before_action :set_user, only: %i[edit update]
+  before_action :set_user, only: %i[show edit update]
 
   def index
     @users = User.all.order(created_at: :desc)
   end
+
+  def show; end
 
   def edit; end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,28 @@
 class Admin::UsersController < Admin::BaseController
+  before_action :set_user, only: %i[edit update]
+
   def index
     @users = User.all.order(created_at: :desc)
+  end
+
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_users_path, success: 'アカウント情報を編集しました'
+    else
+      flash.now['danger'] = 'アカウント情報の変更に失敗しました'
+      render :edit
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :phonenumber, :role)
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,8 @@ class Admin::UsersController < Admin::BaseController
   before_action :set_user, only: %i[show edit update destroy]
 
   def index
-    @users = User.all.order(created_at: :desc).page(params[:page])
+    @q = User.ransack(params[:q])
+    @users = @q.result.order(created_at: :desc).page(params[:page])
   end
 
   def show; end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -11,7 +11,7 @@ class Admin::UsersController < Admin::BaseController
 
   def update
     if @user.update(user_params)
-      redirect_to admin_users_path, success: 'アカウント情報を編集しました'
+      redirect_to admin_user_path(@user), success: 'アカウント情報を編集しました'
     else
       flash.now['danger'] = 'アカウント情報の変更に失敗しました'
       render :edit

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,2 +1,5 @@
-class Admin::UsersController < ApplicationController
+class Admin::UsersController < Admin::BaseController
+  def index
+    @users = User.all.order(created_at: :desc)
+  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,7 +2,7 @@ class Admin::UsersController < Admin::BaseController
   before_action :set_user, only: %i[show edit update destroy]
 
   def index
-    @users = User.all.order(created_at: :desc)
+    @users = User.all.order(created_at: :desc).page(params[:page])
   end
 
   def show; end

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -10,7 +10,7 @@
           <% end %>
         </li>
         <li class="nav-item">
-          <%= link_to admin_root_path, class: "nav-link" do %>
+          <%= link_to admin_users_path, class: "nav-link" do %>
             <i class="nav-icon far fa-user"></i>
             <p>ユーザー</p>
           <% end %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_with model: @user, url: admin_user_path(@user), local: true do |f| %>
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: "form-control", required: true %>
+  </div>
+  <div class="form-group">
+    <%= f.label :email %>
+    <%= f.text_field :email, class: "form-control", required: true %>
+  </div>
+  <div class="form-group">
+    <%= f.label :phonenumber %>
+    <%= f.telephone_field :phonenumber, class: "form-control", required: true %>
+  </div>
+  <div class="form-group">
+    <%= f.label :role %>
+    <%= f.text_field :role, class: "form-control", required: true %>
+  </div>
+  <%= f.submit "更新", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -3,11 +3,11 @@
     <%= user.name %>
   </td>
   <td class="text-nowrap text-right mr-1">
-    <%#= link_to admin_user_path(user), class: "btn btn-info" do %>
+    <%= link_to admin_user_path(user), class: "btn btn-info" do %>
       <i class="fas fa-search-plus"></i>詳細
-      <#% end%>
-        <%= link_to edit_admin_user_path(user), class: "btn btn-success" do %>
-          <i class="far fa-edit"></i>編集
-        <% end%>
-      </td>
-    </tr>
+    <% end%>
+    <%= link_to edit_admin_user_path(user), class: "btn btn-success" do %>
+      <i class="far fa-edit"></i>編集
+    <% end%>
+  </td>
+</tr>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -6,8 +6,8 @@
     <%#= link_to admin_user_path(user), class: "btn btn-info" do %>
       <i class="fas fa-search-plus"></i>詳細
       <#% end%>
-        <%#= link_to edit_admin_user_path(user), class: "btn btn-success" do %>
+        <%= link_to edit_admin_user_path(user), class: "btn btn-success" do %>
           <i class="far fa-edit"></i>編集
-          <#% end%>
-          </td>
-        </tr>
+        <% end%>
+      </td>
+    </tr>

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -1,0 +1,13 @@
+<tr>
+  <td class="text-nowrap">
+    <%= user.name %>
+  </td>
+  <td class="text-nowrap text-right mr-1">
+    <%#= link_to admin_user_path(user), class: "btn btn-info" do %>
+      <i class="fas fa-search-plus"></i>詳細
+      <#% end%>
+        <%#= link_to edit_admin_user_path(user), class: "btn btn-success" do %>
+          <i class="far fa-edit"></i>編集
+          <#% end%>
+          </td>
+        </tr>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,13 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <div class="my-3">
+        <h2>ユーザー編集</h2>
+      </div>
+      <%= render "form" %>
+      <div class="text-center mb-3">
+        <%= link_to "一覧へ", admin_users_path, class: "btn btn-secondary" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,9 +2,6 @@
   <div class="my-3">
     <h2>ユーザー</h2>
   </div>
-  <div class="text-center mb-3">
-    <%#= link_to "新規予約", new_administrator_reservation_path, class: "btn btn-primary" %>
-  </div>
   <div class="row">
     <div class="col-md-12">
       <div class="table-responsive">

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -19,4 +19,7 @@
       </div>
     </div>
   </div>
+  <div class="row justify-content-center">
+    <%= paginate @users %>
+  </div>
 </div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -3,6 +3,22 @@
     <h2>ユーザー</h2>
   </div>
   <div class="row">
+    <div class="col-md-12 mb-3">
+      <%= search_form_for @q, url: admin_users_path  do |f| %>
+        <div class="row">
+          <div class="form-inline align-items-center mx-auto">
+            <div class="col-auto">
+              <%= f.search_field :name_cont, class: "form-control", placeholder: "名前" %>
+            </div>
+            <div class="col-auto">
+              <%= f.submit "検索",  class: "btn btn-primary" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <div class="row">
     <div class="col-md-12">
       <div class="table-responsive">
         <table class="table table-striped">

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,25 @@
+<div class="container p-3 p-md-4 p-lg-5">
+  <div class="my-3">
+    <h2>ユーザー</h2>
+  </div>
+  <div class="text-center mb-3">
+    <%#= link_to "新規予約", new_administrator_reservation_path, class: "btn btn-primary" %>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="table-responsive">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th scope="col" class="text-nowrap">名前</th>
+              <th scope="col" class="text-nowrap"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= render @users %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -8,39 +8,39 @@
         <%= link_to edit_admin_user_path(@user), class: "btn btn-success" do %>
           <i class="far fa-edit"></i>編集
         <% end %>
-        <%#= link_to admin_user_path(@user), method: :delete, data: { confirm: "２度と戻せません本当に削除してもよろしいですか"}, class: "btn btn-danger" do %>
+        <%= link_to admin_user_path(@user), method: :delete, data: { confirm: "２度と戻せません本当に削除してもよろしいですか"}, class: "btn btn-danger" do %>
           <i class="far fa-trash-alt"></i>削除
-          <#% end %>
-          </div>
-          <table class="table table-bordered bg-white mb-5">
-            <tr>
-              <th scope="row">ID</th>
-              <td><%= @user.id %></td>
-            </tr>
-            <tr>
-              <th scope="row">名前</th>
-              <td><%= @user.name %></td>
-            </tr>
-            <tr>
-              <th scope="row">ユーザー権限</th>
-              <td><%= @user.role %></td>
-            </tr>
-            <tr>
-              <th scope="row">メールアドレス</th>
-              <td><%= @user.email %></td>
-            </tr>
-            <tr>
-              <th scope="row">電話番号</th>
-              <td><%= @user.phonenumber %></td>
-            </tr>
-            <tr>
-              <th scope="row">登録日時</th>
-              <td><%= l @user.created_at, format: :short %></td>
-            </tr>
-          </table>
-          <div class="my-3">
-            <h2>予約履歴</h2>
-          </div>
-        </div>
+        <% end %>
+      </div>
+      <table class="table table-bordered bg-white mb-5">
+        <tr>
+          <th scope="row">ID</th>
+          <td><%= @user.id %></td>
+        </tr>
+        <tr>
+          <th scope="row">名前</th>
+          <td><%= @user.name %></td>
+        </tr>
+        <tr>
+          <th scope="row">ユーザー権限</th>
+          <td><%= @user.role %></td>
+        </tr>
+        <tr>
+          <th scope="row">メールアドレス</th>
+          <td><%= @user.email %></td>
+        </tr>
+        <tr>
+          <th scope="row">電話番号</th>
+          <td><%= @user.phonenumber %></td>
+        </tr>
+        <tr>
+          <th scope="row">登録日時</th>
+          <td><%= l @user.created_at, format: :short %></td>
+        </tr>
+      </table>
+      <div class="my-3">
+        <h2>予約履歴</h2>
       </div>
     </div>
+  </div>
+</div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,46 @@
+<div class="container p-3 p-md-4 p-lg-5">
+  <div class="row">
+    <div class="col-md-10 offset-md-1">
+      <div class="my-3">
+        <h2>ユーザー詳細</h2>
+      </div>
+      <div class="text-right mb-3">
+        <%= link_to edit_admin_user_path(@user), class: "btn btn-success" do %>
+          <i class="far fa-edit"></i>編集
+        <% end %>
+        <%#= link_to admin_user_path(@user), method: :delete, data: { confirm: "２度と戻せません本当に削除してもよろしいですか"}, class: "btn btn-danger" do %>
+          <i class="far fa-trash-alt"></i>削除
+          <#% end %>
+          </div>
+          <table class="table table-bordered bg-white mb-5">
+            <tr>
+              <th scope="row">ID</th>
+              <td><%= @user.id %></td>
+            </tr>
+            <tr>
+              <th scope="row">名前</th>
+              <td><%= @user.name %></td>
+            </tr>
+            <tr>
+              <th scope="row">ユーザー権限</th>
+              <td><%= @user.role %></td>
+            </tr>
+            <tr>
+              <th scope="row">メールアドレス</th>
+              <td><%= @user.email %></td>
+            </tr>
+            <tr>
+              <th scope="row">電話番号</th>
+              <td><%= @user.phonenumber %></td>
+            </tr>
+            <tr>
+              <th scope="row">登録日時</th>
+              <td><%= l @user.created_at %></td>
+            </tr>
+          </table>
+          <div class="my-3">
+            <h2>予約履歴</h2>
+          </div>
+        </div>
+      </div>
+    </div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -35,7 +35,7 @@
             </tr>
             <tr>
               <th scope="row">登録日時</th>
-              <td><%= l @user.created_at %></td>
+              <td><%= l @user.created_at, format: :short %></td>
             </tr>
           </table>
           <div class="my-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,6 @@ Rails.application.routes.draw do
     post 'login', to: 'user_sessions#create'
     delete 'logout', to: 'user_sessions#destroy'
     resources :news
+    resources :users, only: %i[index show edit update destroy]
   end
 end


### PR DESCRIPTION
## Issue 番号

Closes #9

## 概要

- Userの管理者画面を作成
- Userの一覧を表示
- 詳細確認・編集・削除が行える
- 検索機能を追加(gem ransackを使用)
- ページネーションを追加(gem kaminariを使用)

## 参考資料


## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
