### PR TITLE
Feature/reservation

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,0 +1,5 @@
+class ReservationsController < ApplicationController
+  def new; end
+
+  def create; end
+end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,5 +1,22 @@
 class ReservationsController < ApplicationController
-  def new; end
+  def new
+    @reservation = Reservation.new
+  end
 
-  def create; end
+  def create
+    Reservation.transaction do
+      capacity_id = Capacity.find_by(start_time: params[:reservation][:capacity_id]).id
+      @reservation = Reservation.create!(reservation_params.merge(capacity_id: capacity_id))
+      @reservation.capacity.update!(remaining_seat: @reservation.capacity.remaining_seat - @reservation.number_of_people)
+      redirect_to root_path, success: 'ご予約が完了しました。'
+    end
+  rescue StandardError
+    redirect_to new_reservation_path, danger: 'ご予約ができませんでした。店舗までご連絡下さい。'
+  end
+
+  private
+
+  def reservation_params
+    params.require(:reservation).permit(:name, :email, :phonenumber, :number_of_people, :visiting_time, :reservation_status, :capacity_id, :user_id)
+  end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,5 +1,5 @@
 class ReservationsController < ApplicationController
-  def new
+  def index
     @reservation = Reservation.new
   end
 
@@ -11,7 +11,7 @@ class ReservationsController < ApplicationController
       redirect_to root_path, success: 'ご予約が完了しました。'
     end
   rescue StandardError
-    redirect_to new_reservation_path, danger: 'ご予約ができませんでした。店舗までご連絡下さい。'
+    redirect_to reservations_path, danger: 'ご予約ができませんでした。店舗までご連絡下さい。'
   end
 
   private

--- a/app/models/capacity.rb
+++ b/app/models/capacity.rb
@@ -1,0 +1,2 @@
+class Capacity < ApplicationRecord
+end

--- a/app/models/capacity.rb
+++ b/app/models/capacity.rb
@@ -1,2 +1,3 @@
 class Capacity < ApplicationRecord
+  has_many :reservations
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,4 +1,20 @@
 class Reservation < ApplicationRecord
   belongs_to :user
   belongs_to :capacity
+
+  enum visiting_time: {
+    '11:00': 0,
+    '11:30': 1,
+    '12:00': 2,
+    '12:30': 3,
+    '13:00': 4,
+    '13:30': 5,
+    '14:00': 6
+  }
+
+  enum reservation_status: {
+    visiting: 0,
+    visited: 1,
+    cancel: 2
+  }
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -2,6 +2,21 @@ class Reservation < ApplicationRecord
   belongs_to :user
   belongs_to :capacity
 
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  VALID_PHONE_REGEX = /\A\d{10,11}\z/
+
+  validates :name, presence: true, length: { maximum: 20 }
+  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX, message: 'は正しいメールアドレスを入力してください' }, length: { maximum: 256 }
+  validates :phonenumber, presence: true, format: { with: VALID_PHONE_REGEX, message: 'は正しい電話番号を入力してください' }, length: { in: 10..11 }
+  validates :number_of_people, presence: true
+  validates :visiting_time, presence: true
+  validates :reservations_status, presence: true
+  validates :capacity_id, presence: true
+
+  validate :date_before_today
+  validate :start_time_not_sunday
+  validate :start_time_not_monday
+
   enum visiting_time: {
     '11:00': 0,
     '11:30': 1,
@@ -17,4 +32,16 @@ class Reservation < ApplicationRecord
     visited: 1,
     cancel: 2
   }
+
+  def date_before_today
+    errors.add(:start_time, 'は過去の日付は選択できません') if capacity.start_time < Time.zone.today
+  end
+
+  def start_time_not_sunday
+    errors.add(:start_time, 'は定休日(月曜日・日曜日)以外を選択してください') if capacity.start_time.sunday?
+  end
+
+  def start_time_not_monday
+    errors.add(:start_time, 'は定休日(月曜日・日曜日)以外を選択してください') if capacity.start_time.monday?
+  end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -10,7 +10,7 @@ class Reservation < ApplicationRecord
   validates :phonenumber, presence: true, format: { with: VALID_PHONE_REGEX, message: 'は正しい電話番号を入力してください' }, length: { in: 10..11 }
   validates :number_of_people, presence: true
   validates :visiting_time, presence: true
-  validates :reservations_status, presence: true
+  validates :reservation_status, presence: true
   validates :capacity_id, presence: true
 
   validate :date_before_today

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,5 +1,5 @@
 class Reservation < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: true
   belongs_to :capacity
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,0 +1,4 @@
+class Reservation < ApplicationRecord
+  belongs_to :user
+  belongs_to :capacity
+end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -2,8 +2,8 @@ class Reservation < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :capacity
 
-  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-  VALID_PHONE_REGEX = /\A\d{10,11}\z/
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
+  VALID_PHONE_REGEX = /\A\d{10,11}\z/.freeze
 
   validates :name, presence: true, length: { maximum: 20 }
   validates :email, presence: true, format: { with: VALID_EMAIL_REGEX, message: 'は正しいメールアドレスを入力してください' }, length: { maximum: 256 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  has_many :reservations
+
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)\w{8,36}\z/.freeze
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i.freeze
   VALID_PHONE_REGEX = /\A\d{10,11}\z/.freeze

--- a/app/views/reservations/_form.html.erb
+++ b/app/views/reservations/_form.html.erb
@@ -1,0 +1,62 @@
+<%= form_with model: @reservation, url: reservations_path, local: true, id: "reservation_form" do |f| %>
+  <%= f.hidden_field :user_id, value: current_user&.id %>
+  <div class="form-group">
+    <div class="text-left mb-1">
+      <%= f.label :name %>
+    </div>
+    <div class="mb-3">
+      <%= f.text_field :name, value: current_user&.name, class: "form-control", placeholder: "(例)ほのぼの太郎", required: true %>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="text-left mb-1">
+      <%= f.label :email %>
+    </div>
+    <div class="mb-3">
+      <%= f.email_field :email, value: current_user&.email, class: "form-control", placeholder: "(例)lunchcafe@honobono.com", required: true %>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="text-left mb-1">
+      <%= f.label :phonenumber %>
+    </div>
+    <div class="mb-3">
+      <%= f.telephone_field :phonenumber, value: current_user&.phonenumber, class: "form-control", placeholder: "(例)09012345678", required: true %>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="text-left mb-1">
+      <%= f.label :start_time %>
+    </div>
+    <div class="mb-3">
+      <%= f.date_field :capacity_id, class: "form-control", required: true, min: Date.tomorrow, max: Date.today.since(1.month) %>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="text-left mb-1">
+      <%= f.label :visiting_time %>
+    </div>
+    <div class="mb-3">
+      <%= f.select :visiting_time, Reservation.visiting_times_i18n.invert, {include_blank: "ご来店時間を選択して下さい"}, {class: "form-control", required: true} %>
+    </div>
+  </div>
+  <div class="form-group">
+    <div class="text-left mb-1">
+      <%= f.label :number_of_people %>
+    </div>
+    <div class="mb-3">
+      <%= f.select :number_of_people,[["1名", 1],["2名", 2],["3名", 3],["4名", 4],["5名", 5],["6名", 6],["7名", 7],["8名", 8],["9名", 9],["10名", 10]], {include_blank: "人数を選択して下さい"}, {class: "form-control", required: true} %>
+    </div>
+  </div>
+  <div class="text-left mb-3">
+    <small>・全ての入力項目が必須となっております。</small><br>
+    <small>・ご来店日は明日以降、一ヶ月以内、定休日(日・月曜日)以外を選択して下さい。</small><br>
+    <small>・電話番号はハイフンを除き市外局番から記入をお願いいたします。</small><br>
+    <small>・英数字は半角での記入をお願いいたします。</small><br>
+    <small>・ご入力頂いたメールアドレスに自動で確認メールを送信しております。</small><br>
+    <small>・大人数でのご予約をご希望の際は<%= link_to "お問い合わせページ", root_path %>、もしくはお電話にて店舗までご連絡下さい。</small><br>
+  </div>
+  <div class="actions text-center mb-3">
+    <%= f.submit "規約に同意して次へ", class: "btn btn-success w-100" %>
+  </div>
+<% end %>

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -11,7 +11,7 @@
         </div>
         <div class="text-center mt-3 mb-5">
           <%= link_to "登録ページへ", new_user_path %> / 
-          <%= link_to "パスワードをお忘れの方はこちら", new_password_reset_path %>
+          <%#= link_to "パスワードをお忘れの方はこちら", new_password_reset_path %>
         </div>
         <div class="text-center my-3">
           <h5>会員でない方はこちら</h5>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Reservations#new</h1>
+<p>Find me in app/views/reservations/new.html.erb</p>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -1,2 +1,32 @@
-<h1>Reservations#new</h1>
-<p>Find me in app/views/reservations/new.html.erb</p>
+<div class="container">
+  <h1 class="text-center my-5">ランチのご予約</h1>
+  <div class="row px-2">
+    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <% unless logged_in? %>
+        <div class="text-center mb-3">
+          <h5>会員の方はログインして下さい</h5>
+        </div>
+        <div class="col-md-6 offset-md-3">
+          <%= render "user_sessions/form" %>
+        </div>
+        <div class="text-center mt-3 mb-5">
+          <%= link_to "登録ページへ", new_user_path %> / 
+          <%= link_to "パスワードをお忘れの方はこちら", new_password_reset_path %>
+        </div>
+        <div class="text-center my-3">
+          <h5>会員でない方はこちら</h5>
+        </div>
+      <% end %>
+    </div>
+    <div class="col-12 col-md-8 offset-md-2 col-lg-6 offset-lg-3 border p-3 mb-4">
+      <%= render "form" %>
+      <div class="text-center my-3">
+        <small><%= link_to "利用規約", "/terms" %>、<%= link_to "プライバシーポリシー", "/privacy" %>をご確認の上、ボタンを押してください。</small>
+      </div>
+    </div>
+    <div class="col-12 text-center mb-5">
+      <%= link_to "Homeへ", root_path %>
+    </div>
+  </div>
+</div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
     <%= image_tag("logo.jpg")%>
   <% end %>
   <div class="navbar-nav ml-auto d-block d-lg-none">
-    <%= link_to new_reservation_path do %>
+    <%= link_to reservations_path do %>
       <div class="flex-column text-center">
         <i class="fas fa-calendar-check fa-2x"></i>
         <p class="text-nowrap mb-0">Web予約</p>
@@ -40,7 +40,7 @@
     </ul>
   </div>
   <div class="navbar-nav mr-auto d-none d-lg-block">
-    <%= link_to new_reservation_path do %>
+    <%= link_to reservations_path do %>
       <div class="flex-column mx-3 text-center">
         <i class="fas fa-calendar-check fa-2x"></i>
         <p class="text-nowrap mb-0">Web予約</p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
     <%= image_tag("logo.jpg")%>
   <% end %>
   <div class="navbar-nav ml-auto d-block d-lg-none">
-    <%= link_to root_path do %>
+    <%= link_to new_reservation_path do %>
       <div class="flex-column text-center">
         <i class="fas fa-calendar-check fa-2x"></i>
         <p class="text-nowrap mb-0">Web予約</p>
@@ -40,7 +40,7 @@
     </ul>
   </div>
   <div class="navbar-nav mr-auto d-none d-lg-block">
-    <%= link_to root_path do %>
+    <%= link_to new_reservation_path do %>
       <div class="flex-column mx-3 text-center">
         <i class="fas fa-calendar-check fa-2x"></i>
         <p class="text-nowrap mb-0">Web予約</p>

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -6,3 +6,8 @@ ja:
         event: 'イベント'
         menu: 'メニュー'
         campaign: 'キャンペーン'
+    reservation:
+      reservation_status:
+        visiting: '来店予約'
+        visited: '来店済'
+        cancel: 'キャンセル'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,12 +2,27 @@ ja:
   activerecord:
     models:
       news: ニュース
+      reservation: 予約
+      capacity: キャパシティー
     attributes:
       news:
         title: タイトル
         body: 内容
         category: カテゴリー
         news_image: ニュース画像
+      reservation:
+        name: お名前
+        email: メールアドレス
+        phonenumber: 電話番号
+        number_of_people: 人数
+        visiting_time: ご来店日
+        reservation_status: 予約ステータス
+        start_time: ご来店日
+        capacity_id: 日付ID
+        user_id: ユーザーID
+      capacity:
+        start_time: 予約日
+        remaining_seat: 席数
   views:
     pagination:
       first: <i class="fas fa-angle-double-left"></i>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   get 'privacy', to: 'static_pages#privacy'
   get 'shop', to: 'static_pages#shop'
 
-  resources :reservations, only: %i[new create]
+  resources :reservations, only: %i[index create]
 
   resources :users, only: %i[new create]
   get '/mypage', to: 'users#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   get 'privacy', to: 'static_pages#privacy'
   get 'shop', to: 'static_pages#shop'
 
+  resources :reservations, only: %i[new create]
+
   resources :users, only: %i[new create]
   get '/mypage', to: 'users#show'
   get '/mypage/edit', to: 'users#edit'

--- a/db/migrate/20211121132600_create_capacities.rb
+++ b/db/migrate/20211121132600_create_capacities.rb
@@ -1,0 +1,10 @@
+class CreateCapacities < ActiveRecord::Migration[6.0]
+  def change
+    create_table :capacities do |t|
+      t.date :start_time, null: false
+      t.integer :remaining_seat, default: 20, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211122131024_create_reservations.rb
+++ b/db/migrate/20211122131024_create_reservations.rb
@@ -1,0 +1,16 @@
+class CreateReservations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :reservations do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.string :phonenumber, null: false
+      t.integer :number_of_people, null: false
+      t.integer :visiting_time, null: false
+      t.integer :reservation_status, default: 0, null: false
+      t.references :user, foreign_key: true
+      t.references :capacity, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_21_132600) do
+ActiveRecord::Schema.define(version: 2021_11_22_131024) do
 
   create_table "capacities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.date "start_time", null: false
@@ -28,6 +28,21 @@ ActiveRecord::Schema.define(version: 2021_11_21_132600) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "reservations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "phonenumber", null: false
+    t.integer "number_of_people", null: false
+    t.integer "visiting_time", null: false
+    t.integer "reservation_status", default: 0, null: false
+    t.bigint "user_id"
+    t.bigint "capacity_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["capacity_id"], name: "index_reservations_on_capacity_id"
+    t.index ["user_id"], name: "index_reservations_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
@@ -40,4 +55,6 @@ ActiveRecord::Schema.define(version: 2021_11_21_132600) do
     t.index ["email", "phonenumber"], name: "index_users_on_email_and_phonenumber", unique: true
   end
 
+  add_foreign_key "reservations", "capacities"
+  add_foreign_key "reservations", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_12_142658) do
+ActiveRecord::Schema.define(version: 2021_11_21_132600) do
+
+  create_table "capacities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.date "start_time", null: false
+    t.integer "remaining_seat", default: 20, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "news", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "title", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,8 @@
-User.create!(name: '管理者', email: 'admin@example.com', phonenumber: '0700000000', password: 'test1111', password_confirmation: 'test1111', role: 1)
+# User.create!(name: '管理者', email: 'admin@example.com', phonenumber: '0700000000', password: 'test1111', password_confirmation: 'test1111', role: 1)
 puts '管理者のテストデータ挿入'
+
+30.times do |i|
+  date = Date.today + i
+  Capacity.create(start_time: date)
+end
+puts 'Capacityのテストデータ挿入'


### PR DESCRIPTION
## Issue 番号

Closes #10 

## 概要

- 予約のデータをもつReservationテーブルと日付ごとに予約の上限をもつCapacityテーブルを作成
-  Reservationテーブル、Capacityテーブル、Userテーブルのアソシエーションを設定
- 予約画面のコントローラーの作成
- 予約画面をログインの有無で画面を変更するように設定
- `gem enum_help`をインストールし`enum`で設定した表示名を変更する
- 予約のバリデーションを設定する
  - 予約可能人数はマイナスにならない
  - 定休日は予約できない
  - 当日、過去の日付は予約できない
  - 一ヶ月後以降の日付は予約できない
  - reservationsテーブルのuser_idは`notnull制約`をせずuserに対して`optional: true`を設定
- `reservation`,`capacity`モデルの日本語訳を追加

## 参考資料

マークダウン記法のリンクを用いて記載すること

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
