### PR TITLE
予約の管理者機能を作成

### DIFF
--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -3,7 +3,8 @@ class Admin::ReservationsController < Admin::BaseController
   before_action :assign_to_capacity_id, only: %i[create update]
 
   def index
-    @reservations = Reservation.order(capacity_id: 'desc').page(params[:page])
+    @q = Reservation.ransack(params[:q])
+    @reservations = @q.result.order(capacity_id: 'desc').page(params[:page])
   end
 
   def show; end

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -1,0 +1,13 @@
+class Admin::ReservationsController < Admin::BaseController
+  def index; end
+
+  def new; end
+
+  def create; end
+
+  def edit; end
+
+  def update; end
+
+  def destroy; end
+end

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -3,7 +3,7 @@ class Admin::ReservationsController < Admin::BaseController
   before_action :assign_to_capacity_id, only: %i[create update]
 
   def index
-    @reservations = Reservation.all.order(capacity_id: 'desc')
+    @reservations = Reservation.order(capacity_id: 'desc').page(params[:page])
   end
 
   def show; end

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -1,5 +1,5 @@
 class Admin::ReservationsController < Admin::BaseController
-  before_action :set_reservation, only: %i[show edit update]
+  before_action :set_reservation, only: %i[show edit update destroy]
 
   def index
     @reservations = Reservation.all.order(capacity_id: 'desc')
@@ -38,7 +38,13 @@ class Admin::ReservationsController < Admin::BaseController
     render :edit
   end
 
-  def destroy; end
+  def destroy
+    Reservation.transaction do
+      @reservation.capacity.update!(remaining_seat: @reservation.capacity.remaining_seat + @reservation.number_of_people)
+      @reservation.destroy!
+      redirect_to admin_reservations_path, success: '予約をを削除しました'
+    end
+  end
 
   private
 

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -3,7 +3,9 @@ class Admin::ReservationsController < Admin::BaseController
     @reservations = Reservation.all.order(capacity_id: 'desc')
   end
 
-  def show; end
+  def show
+    @reservation = Reservation.find(params[:id])
+  end
 
   def new; end
 

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -15,7 +15,7 @@ class Admin::ReservationsController < Admin::BaseController
     Reservation.transaction do
       capacity_id = Capacity.find_by(start_time: params[:reservation][:capacity_id]).id
       @reservation = Reservation.create!(reservation_params.merge(capacity_id: capacity_id))
-      @reservation.capacity.update!(remaining_seat: @reservation.capacity.remaining_seat - @reservation.number_of_people)
+      @reservation.capacity.update!(remaining_seat: @reservation.decreased_capacity)
       redirect_to admin_reservations_path, success: '予約が完了しました'
     end
   rescue StandardError
@@ -28,9 +28,9 @@ class Admin::ReservationsController < Admin::BaseController
   def update
     Reservation.transaction do
       @capacity_id = Capacity.find_by(start_time: params[:reservation][:capacity_id]).id
-      @reservation.capacity.update!(remaining_seat: @reservation.capacity.remaining_seat + @reservation.number_of_people)
+      @reservation.capacity.update!(remaining_seat: @reservation.increased_capacity)
       @reservation.update!(reservation_params.merge(capacity_id: @capacity_id))
-      @reservation.capacity.update!(remaining_seat: @reservation.capacity.remaining_seat - @reservation.number_of_people)
+      @reservation.capacity.update!(remaining_seat: @reservation.decreased_capacity)
       redirect_to admin_reservations_path, success: '予約の変更が完了しました'
     end
   rescue StandardError
@@ -40,7 +40,7 @@ class Admin::ReservationsController < Admin::BaseController
 
   def destroy
     Reservation.transaction do
-      @reservation.capacity.update!(remaining_seat: @reservation.capacity.remaining_seat + @reservation.number_of_people)
+      @reservation.capacity.update!(remaining_seat: @reservation.increased_capacity)
       @reservation.destroy!
       redirect_to admin_reservations_path, success: '予約をを削除しました'
     end
@@ -48,7 +48,7 @@ class Admin::ReservationsController < Admin::BaseController
 
   def cancel
     Reservation.transaction do
-      @reservation.capacity.update!(remaining_seat: @reservation.capacity.remaining_seat + @reservation.number_of_people)
+      @reservation.capacity.update!(remaining_seat: @reservation.increased_capacity)
       @reservation.update!(reservation_status: 'cancel')
       redirect_to admin_reservations_path, success: 'キャンセルが完了しました'
     end

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -28,4 +28,10 @@ class Admin::ReservationsController < Admin::BaseController
   def update; end
 
   def destroy; end
+
+  private
+
+  def reservation_params
+    params.require(:reservation).permit(:name, :email, :phonenumber, :number_of_people, :visiting_time, :reservation_status, :capacity_id, :user_id)
+  end
 end

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -1,5 +1,7 @@
 class Admin::ReservationsController < Admin::BaseController
-  def index; end
+  def index
+    @reservations = Reservation.all.order(capacity_id: 'desc')
+  end
 
   def show; end
 

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -1,6 +1,8 @@
 class Admin::ReservationsController < Admin::BaseController
   def index; end
 
+  def show; end
+
   def new; end
 
   def create; end

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -7,9 +7,21 @@ class Admin::ReservationsController < Admin::BaseController
     @reservation = Reservation.find(params[:id])
   end
 
-  def new; end
+  def new
+    @reservation = Reservation.new
+  end
 
-  def create; end
+  def create
+    Reservation.transaction do
+      capacity_id = Capacity.find_by(start_time: params[:reservation][:capacity_id]).id
+      @reservation = Reservation.create!(reservation_params.merge(capacity_id: capacity_id))
+      @reservation.capacity.update!(remaining_seat: @reservation.capacity.remaining_seat - @reservation.number_of_people)
+      redirect_to admin_reservations_path, success: '予約が完了しました'
+    end
+  rescue StandardError
+    flash.now['danger'] = "予約ができませんでした \n 今日以降の定休日以外の日付を入力してください \n 予約日の席数を確認してください"
+    render :new
+  end
 
   def edit; end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -6,7 +6,9 @@ class Admin::UsersController < Admin::BaseController
     @users = @q.result.order(created_at: :desc).page(params[:page])
   end
 
-  def show; end
+  def show
+    @reservations = @user.reservations.order(created_at: :desc).page(params[:page]).per(5)
+  end
 
   def edit; end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,7 +7,7 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def show
-    @reservations = @user.reservations.order(created_at: :desc).page(params[:page]).per(5)
+    @reservations = @user.reservations.order(created_at: :desc).page(params[:page]).per(User::PER_PAGE)
   end
 
   def edit; end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -7,7 +7,7 @@ class ReservationsController < ApplicationController
     Reservation.transaction do
       capacity_id = Capacity.find_by(start_time: params[:reservation][:capacity_id]).id
       @reservation = Reservation.create!(reservation_params.merge(capacity_id: capacity_id))
-      @reservation.capacity.update!(remaining_seat: @reservation.capacity.remaining_seat - @reservation.number_of_people)
+      @reservation.capacity.update!(remaining_seat: @reservation.decreased_capacity)
       redirect_to root_path, success: 'ご予約が完了しました。'
     end
   rescue StandardError

--- a/app/models/capacity.rb
+++ b/app/models/capacity.rb
@@ -1,3 +1,5 @@
 class Capacity < ApplicationRecord
   has_many :reservations
+
+  validates :remaining_seat, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -44,4 +44,14 @@ class Reservation < ApplicationRecord
   def start_time_not_monday
     errors.add(:start_time, 'は定休日(月曜日・日曜日)以外を選択してください') if capacity.start_time.monday?
   end
+
+  # 席数から予約人数をマイナスする
+  def decreased_capacity
+    capacity.remaining_seat - number_of_people
+  end
+
+  # 席数に変更人数をプラスする
+  def increased_capacity
+    capacity.remaining_seat + number_of_people
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,6 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
   enum role: { general: 0, admin: 1 }
+
+  PER_PAGE = 5
 end

--- a/app/views/admin/reservations/_editform.html.erb
+++ b/app/views/admin/reservations/_editform.html.erb
@@ -1,0 +1,31 @@
+<%= form_with model: @reservation, url: admin_reservation_path(@reservation), local: true do |f| %>
+  <div class="form-group">
+    <%= f.label :name %> *必須
+    <%= f.text_field :name, class: "form-control", required: true %>
+  </div>
+  <div class="form-group">
+    <%= f.label :email %> *必須
+    <%= f.email_field :email, class: "form-control", required: true %>
+  </div>
+  <div class="form-group">
+    <%= f.label :phonenumber %> *必須
+    <%= f.telephone_field :phonenumber, class: "form-control", required: true %>
+  </div>
+    <div class="form-group">
+    <%= f.label :start_time %> *必須
+    <%= f.date_field :capacity_id, class: "form-control", required: true %>
+  </div>
+  <div class="form-group">
+    <%= f.label :visiting_time %> *必須
+    <%= f.select :visiting_time, Reservation.visiting_times_i18n.invert, {}, {class: "form-control", required: true} %>
+  </div>
+  <div class="form-group">
+    <%= f.label :number_of_people %> *必須
+    <%= f.select :number_of_people,[["1名", 1],["2名", 2],["3名", 3],["4名", 4],["5名", 5],["6名", 6],["7名", 7],["8名", 8],["9名", 9],["10名", 10]], {}, {class: "form-control", required: true} %>
+  </div>
+  <div class="form-group">
+    <%= f.label :reservation_status %>
+    <%= f.select :reservation_status, Reservation.reservation_statuses_i18n.invert, {}, {class: "form-control", required: true} %>
+  </div>
+  <%= f.submit "変更", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/admin/reservations/_form.html.erb
+++ b/app/views/admin/reservations/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_with model: @reservation, url: admin_reservations_path, local: true do |f| %>
+  <div class="form-group">
+    <%= f.label :user_id %> *user登録されてるuserの場合アカウントのIDを入力
+    <%= f.text_field :user_id, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= f.label :name %> *必須
+    <%= f.text_field :name, class: "form-control", required: true %>
+  </div>
+  <div class="form-group">
+    <%= f.label :email %> *必須
+    <%= f.email_field :email, class: "form-control", required: true %>
+  </div>
+  <div class="form-group">
+    <%= f.label :phonenumber %> *必須
+    <%= f.telephone_field :phonenumber, class: "form-control", required: true %>
+  </div>
+  <div class="form-group">
+    <%= f.label :start_time %> *必須
+    <%= f.date_field :capacity_id, class: "form-control", required: true %>
+  </div>
+  <div class="form-group">
+    <%= f.label :visiting_time %> *必須
+    <%= f.select :visiting_time, Reservation.visiting_times_i18n.invert, {}, {class: 'form-control', required: true} %>
+  </div>
+  <div class="form-group">
+    <%= f.label :number_of_people %> *必須
+    <%= f.select :number_of_people,[["1名", 1],["2名", 2],["3名", 3],["4名", 4],["5名", 5],["6名", 6],["7名", 7],["8名", 8],["9名", 9],["10名", 10]], {}, {class: "form-control", required: true} %>
+  </div>
+  <%= f.submit "予約", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/admin/reservations/_reservation.html.erb
+++ b/app/views/admin/reservations/_reservation.html.erb
@@ -1,0 +1,25 @@
+<tr>
+  <td class="text-nowrap">
+    <%= l reservation.capacity.start_time, format: :short %>
+  </td>
+  <td class="text-nowrap">
+    <%= reservation.visiting_time %>
+  </td>
+  <td class="text-nowrap">
+    <%= reservation.name %>
+  </td>
+  <td class="text-nowrap">
+    <%= reservation.number_of_people %>
+  </td>
+  <td class="text-nowrap">
+    <%= reservation.reservation_status_i18n %>
+  </td>
+  <td class="text-nowrap">
+    <%= link_to admin_reservation_path(reservation), class: "btn btn-info" do %>
+      <i class="fas fa-search-plus"></i>詳細
+    <% end%>
+    <%= link_to edit_admin_reservation_path(reservation), class: "btn btn-success" do %>
+      <i class="far fa-edit"></i>変更
+    <% end%>
+  </td>
+</tr>

--- a/app/views/admin/reservations/edit.html.erb
+++ b/app/views/admin/reservations/edit.html.erb
@@ -1,0 +1,13 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <div class="my-3">
+        <h2>予約変更</h2>
+      </div>
+      <%= render "editform" %>
+      <div class="text-center mb-3">
+        <%= link_to '一覧へ', admin_reservations_path, class: "btn btn-secondary" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/reservations/index.html.erb
+++ b/app/views/admin/reservations/index.html.erb
@@ -2,6 +2,9 @@
   <div class="my-3">
     <h2>予約</h2>
   </div>
+  <div class="text-center mb-3">
+    <%= link_to "新規予約", new_admin_reservation_path, class: "btn btn-primary" %>
+  </div>
   <div class="row">
     <div class="col-md-12">
       <div class="table-responsive">

--- a/app/views/admin/reservations/index.html.erb
+++ b/app/views/admin/reservations/index.html.erb
@@ -2,6 +2,22 @@
   <div class="my-3">
     <h2>予約</h2>
   </div>
+  <div class="row">
+    <div class="col-md-12 mb-3">
+      <%= search_form_for @q, url: admin_reservations_path  do |f| %>
+        <div class="row">
+          <div class="form-inline align-items-center mx-auto">
+            <div class="col-auto">
+              <%= f.search_field :name_cont, class: "form-control", placeholder: "名前" %>
+            </div>
+            <div class="col-auto">
+              <%= f.submit "検索",  class: "btn btn-primary" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
   <div class="text-center mb-3">
     <%= link_to "新規予約", new_admin_reservation_path, class: "btn btn-primary" %>
   </div>

--- a/app/views/admin/reservations/index.html.erb
+++ b/app/views/admin/reservations/index.html.erb
@@ -1,0 +1,26 @@
+<div class="container p-3 p-md-4 p-lg-5">
+  <div class="my-3">
+    <h2>予約</h2>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="table-responsive">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th scope="col" class="text-nowrap">日にち</th>
+              <th scope="col" class="text-nowrap">時間</th>
+              <th scope="col" class="text-nowrap">名前</th>
+              <th scope="col" class="text-nowrap">人数</th>
+              <th scope="col" class="text-nowrap">ステータス</th>
+              <th scope="col" class="text-nowrap"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= render @reservations %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/reservations/index.html.erb
+++ b/app/views/admin/reservations/index.html.erb
@@ -26,4 +26,7 @@
       </div>
     </div>
   </div>
+  <div class="row justify-content-center">
+    <%= paginate @reservations %>
+  </div>
 </div>

--- a/app/views/admin/reservations/new.html.erb
+++ b/app/views/admin/reservations/new.html.erb
@@ -1,0 +1,13 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <div class="my-3">
+        <h2>新規予約</h2>
+      </div>
+      <%= render "form" %>
+      <div class="text-center mb-3">
+        <%= link_to "一覧へ", admin_reservations_path, class: "btn btn-secondary" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/reservations/show.html.erb
+++ b/app/views/admin/reservations/show.html.erb
@@ -8,58 +8,58 @@
         <%= link_to edit_admin_reservation_path(@reservation), class: "btn btn-success" do %>
           <i class="far fa-edit"></i>予約変更
         <% end %>
-        <%#= link_to "/administrator/reservations/cancel/#{@reservation.id}", method: :patch, data: {confirm: "本当にキャンセルしてもよろしいですか?"}, class: "btn btn-warning" do %>
+        <%= link_to "/admin/reservations/cancel/#{@reservation.id}", method: :patch, data: {confirm: "本当にキャンセルしてもよろしいですか?"}, class: "btn btn-warning" do %>
           <i class="fas fa-ban"></i>キャンセル
-          <#% end %>
-            <%= link_to admin_reservation_path(@reservation), method: :delete, data: { confirm: "２度と戻せません本当に削除してもよろしいですか"}, class: "btn btn-danger" do %>
-              <i class="far fa-trash-alt"></i>削除
-            <% end %>
-          </div>
-          <table class="table table-bordered bg-white">
-            <tr>
-              <th scope="row" class="text-nowrap">予約番号</th>
-              <td><%= @reservation.id %></td>
-            </tr>
-            <tr>
-              <th scope="row" class="text-nowrap">日にち</th>
-              <td><%= l @reservation.capacity.start_time, format: :long %></td>
-            </tr>
-            <tr>
-              <th scope="row" class="text-nowrap">時間</th>
-              <td><%= @reservation.visiting_time %></td>
-            </tr>
-            <tr>
-              <th scope="row" class="text-nowrap">人数</th>
-              <td><%= @reservation.number_of_people %></td>
-            </tr>
-            <tr>
-              <th scope="row" class="text-nowrap">名前</th>
-              <td><%= @reservation.name %></td>
-            </tr>
-            <tr>
-              <th scope="row" class="text-nowrap">メールアドレス</th>
-              <td><%= @reservation.email %></td>
-            </tr>
-            <tr>
-              <th scope="row" class="text-nowrap">電話番号</th>
-              <td><%= @reservation.phonenumber %></td>
-            </tr>
-            <tr>
-              <th scope="row" class="text-nowrap">ステータス</th>
-              <td><%= @reservation.reservation_status_i18n %></td>
-            </tr>
-            <tr>
-              <th scope="row" class="text-nowrap">予約アカウント</th>
-              <% if @reservation.user.present? %>
-                <td><%= link_to "#{@reservation.user.name}", admin_user_path(@reservation.user) %></td>
-              <% else %>
-                <td>ゲスト</td>
-              <% end %>
-            </tr>
-          </table>
-          <div class="text-center mb-3">
-            <%= link_to "一覧へ", admin_reservations_path, class: "btn btn-secondary" %>
-          </div>
-        </div>
+        <% end %>
+        <%= link_to admin_reservation_path(@reservation), method: :delete, data: { confirm: "２度と戻せません本当に削除してもよろしいですか"}, class: "btn btn-danger" do %>
+          <i class="far fa-trash-alt"></i>削除
+        <% end %>
+      </div>
+      <table class="table table-bordered bg-white">
+        <tr>
+          <th scope="row" class="text-nowrap">予約番号</th>
+          <td><%= @reservation.id %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="text-nowrap">日にち</th>
+          <td><%= l @reservation.capacity.start_time, format: :long %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="text-nowrap">時間</th>
+          <td><%= @reservation.visiting_time %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="text-nowrap">人数</th>
+          <td><%= @reservation.number_of_people %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="text-nowrap">名前</th>
+          <td><%= @reservation.name %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="text-nowrap">メールアドレス</th>
+          <td><%= @reservation.email %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="text-nowrap">電話番号</th>
+          <td><%= @reservation.phonenumber %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="text-nowrap">ステータス</th>
+          <td><%= @reservation.reservation_status_i18n %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="text-nowrap">予約アカウント</th>
+          <% if @reservation.user.present? %>
+            <td><%= link_to "#{@reservation.user.name}", admin_user_path(@reservation.user) %></td>
+          <% else %>
+            <td>ゲスト</td>
+          <% end %>
+        </tr>
+      </table>
+      <div class="text-center mb-3">
+        <%= link_to "一覧へ", admin_reservations_path, class: "btn btn-secondary" %>
       </div>
     </div>
+  </div>
+</div>

--- a/app/views/admin/reservations/show.html.erb
+++ b/app/views/admin/reservations/show.html.erb
@@ -1,0 +1,65 @@
+<div class="container p-3 p-md-4 p-lg-5">
+  <div class="row">
+    <div class="col-md-10 offset-md-1">
+      <div class="my-3">
+        <h2>予約詳細</h2>
+      </div>
+      <div class="text-right mb-3">
+        <%= link_to edit_admin_reservation_path(@reservation), class: "btn btn-success" do %>
+          <i class="far fa-edit"></i>予約変更
+        <% end %>
+        <%#= link_to "/administrator/reservations/cancel/#{@reservation.id}", method: :patch, data: {confirm: "本当にキャンセルしてもよろしいですか?"}, class: "btn btn-warning" do %>
+          <i class="fas fa-ban"></i>キャンセル
+          <#% end %>
+            <%= link_to admin_reservation_path(@reservation), method: :delete, data: { confirm: "２度と戻せません本当に削除してもよろしいですか"}, class: "btn btn-danger" do %>
+              <i class="far fa-trash-alt"></i>削除
+            <% end %>
+          </div>
+          <table class="table table-bordered bg-white">
+            <tr>
+              <th scope="row" class="text-nowrap">予約番号</th>
+              <td><%= @reservation.id %></td>
+            </tr>
+            <tr>
+              <th scope="row" class="text-nowrap">日にち</th>
+              <td><%= l @reservation.capacity.start_time, format: :long %></td>
+            </tr>
+            <tr>
+              <th scope="row" class="text-nowrap">時間</th>
+              <td><%= @reservation.visiting_time %></td>
+            </tr>
+            <tr>
+              <th scope="row" class="text-nowrap">人数</th>
+              <td><%= @reservation.number_of_people %></td>
+            </tr>
+            <tr>
+              <th scope="row" class="text-nowrap">名前</th>
+              <td><%= @reservation.name %></td>
+            </tr>
+            <tr>
+              <th scope="row" class="text-nowrap">メールアドレス</th>
+              <td><%= @reservation.email %></td>
+            </tr>
+            <tr>
+              <th scope="row" class="text-nowrap">電話番号</th>
+              <td><%= @reservation.phonenumber %></td>
+            </tr>
+            <tr>
+              <th scope="row" class="text-nowrap">ステータス</th>
+              <td><%= @reservation.reservation_status_i18n %></td>
+            </tr>
+            <tr>
+              <th scope="row" class="text-nowrap">予約アカウント</th>
+              <% if @reservation.user.present? %>
+                <td><%= link_to "#{@reservation.user.name}", admin_user_path(@reservation.user) %></td>
+              <% else %>
+                <td>ゲスト</td>
+              <% end %>
+            </tr>
+          </table>
+          <div class="text-center mb-3">
+            <%= link_to "一覧へ", admin_reservations_path, class: "btn btn-secondary" %>
+          </div>
+        </div>
+      </div>
+    </div>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -16,7 +16,7 @@
           <% end %>
         </li>
         <li class="nav-item">
-          <%= link_to admin_root_path, class: "nav-link" do %>
+          <%= link_to admin_reservations_path, class: "nav-link" do %>
             <i class="nav-icon far fa-calendar-check"></i>
             <p>予約一覧</p>
           <% end %>

--- a/app/views/admin/users/_reservation.html.erb
+++ b/app/views/admin/users/_reservation.html.erb
@@ -1,0 +1,19 @@
+<tr>
+  <td class="text-nowrap">
+    <%= l reservation.capacity.start_time, format: :long%>
+  </td>
+  <td class="text-nowrap">
+    <%= reservation.visiting_time %>
+  </td>
+  <td class="text-nowrap">
+    <%= reservation.number_of_people %>名
+  </td>
+  <td class="text-nowrap">
+    <%= reservation.reservation_status_i18n %>
+  </td>
+  <td class="text-nowrap">
+    <%= link_to admin_reservation_path(reservation), class: "btn btn-info" do %>
+      <i class="fas fa-search-plus"></i>詳細
+    <% end%>
+  </td>
+</tr>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -41,6 +41,28 @@
       <div class="my-3">
         <h2>予約履歴</h2>
       </div>
+      <div class="table-responsive">
+        <table class="table table-bordered bg-white">
+          <thead>
+            <tr>
+              <th scope="col">来店日</th>
+              <th scope="col">時間</th>
+              <th scope="col">人数</th>
+              <th scope="col">ステータス</th>
+              <th scope="col"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= render partial: "admin/users/reservation", collection:  @reservations %>
+          </tbody>
+        </table>
+      </div>
+      <div class="row justify-content-center">
+        <%= paginate @reservations %>
+      </div>
+      <div class="text-center mb-3">
+        <%= link_to "一覧へ", admin_reservations_path, class: "btn btn-secondary" %>
+      </div>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,6 @@ Rails.application.routes.draw do
     delete 'logout', to: 'user_sessions#destroy'
     resources :news
     resources :users, only: %i[index show edit update destroy]
+    resources :reservations
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,5 +23,6 @@ Rails.application.routes.draw do
     resources :news
     resources :users, only: %i[index show edit update destroy]
     resources :reservations
+    patch '/reservations/cancel/:id', to: 'reservations#cancel'
   end
 end


### PR DESCRIPTION
## Issue 番号

Closes #11 

## 概要

- 予約の一覧、詳細、編集、削除、キャンセル機能の実装
- 一覧ページにページネーションと検索機能を追加
- user詳細画面にそのuserの予約履歴を表示
- キャンセル機能
  - 管理者画面でワンクリックで予約をキャンセルできる
  - データは削除せず、予約に紐づく日程の上限人数を元に戻す
  - ステータスをキャンセル済みに変更する
  - キャンセルボタンは詳細画面に設置する
 - reservationsコントローラーをリファクタリング 
## 参考資料


## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
検索機能は一旦は名前検索のみ、必要に応じて追加。