### PR TITLE
予約上限人数管理機能を作成 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'kaminari'
 gem 'enum_help'
 gem 'rails-i18n'
 gem 'ransack'
+gem 'simple_calendar'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,6 +290,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    simple_calendar (2.4.3)
+      rails (>= 3.0)
     sorcery (0.16.1)
       bcrypt (~> 3.1)
       oauth (~> 0.5, >= 0.5.5)
@@ -363,6 +365,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails (>= 6)
+  simple_calendar
   sorcery
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/admin/capacities_controller.rb
+++ b/app/controllers/admin/capacities_controller.rb
@@ -1,10 +1,32 @@
 class Admin::CapacitiesController < Admin::BaseController
+  before_action :set_capacity, only: %i[show edit update]
+
   def index
     @capacities = Capacity.all
   end
 
   def show
-    @capacity = Capacity.find(params[:id])
     @reservations = @capacity.reservations
+  end
+
+  def edit; end
+
+  def update
+    if @capacity.update(capacity_params)
+      redirect_to admin_capacities_path, success: '席数を更新しました'
+    else
+      flash.now[:danger] = '席数を更新できませんでした'
+      render :edit
+    end
+  end
+
+  private
+
+  def set_capacity
+    @capacity = Capacity.find(params[:id])
+  end
+
+  def capacity_params
+    params.require(:capacity).permit(:remaining_seat)
   end
 end

--- a/app/controllers/admin/capacities_controller.rb
+++ b/app/controllers/admin/capacities_controller.rb
@@ -1,0 +1,2 @@
+class Admin::CapacitiesController < Admin::BaseController
+end

--- a/app/controllers/admin/capacities_controller.rb
+++ b/app/controllers/admin/capacities_controller.rb
@@ -2,4 +2,9 @@ class Admin::CapacitiesController < Admin::BaseController
   def index
     @capacities = Capacity.all
   end
+
+  def show
+    @capacity = Capacity.find(params[:id])
+    @reservations = @capacity.reservations
+  end
 end

--- a/app/controllers/admin/capacities_controller.rb
+++ b/app/controllers/admin/capacities_controller.rb
@@ -1,2 +1,5 @@
 class Admin::CapacitiesController < Admin::BaseController
+  def index
+    @capacities = Capacity.all
+  end
 end

--- a/app/views/admin/capacities/_form.html.erb
+++ b/app/views/admin/capacities/_form.html.erb
@@ -1,0 +1,7 @@
+<%= form_with model: @capacity, url: admin_capacity_path(@capacity), local: true do |f| %>
+  <div class="form-group">
+    <%= f.label :remaining_seat %> *必須
+    <%= f.number_field :remaining_seat, class: "form-control", required: true %>
+  </div>
+  <%= f.submit "変更", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/admin/capacities/edit.html.erb
+++ b/app/views/admin/capacities/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <div class="my-3">
+        <h2>席数変更</h2>
+      </div>
+      <%= render "form" %>
+      <div class="text-center">
+        <%= link_to admin_capacities_path, class: "btn btn-secondary" do %>
+          <i class="far fa-calendar-alt"></i>カレンダーへ
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/capacities/index.html.erb
+++ b/app/views/admin/capacities/index.html.erb
@@ -13,6 +13,11 @@
               <%= capacity.remaining_seat%>席
             <% end%>
           </p>
+          <p class="text-nowrap">予約 :
+            <%= link_to admin_capacity_path(capacity) do%>
+              <%= capacity.reservations.count%>件
+            <% end%>
+          </p>
         <% end %>
       <% end %>
     </div>

--- a/app/views/admin/capacities/index.html.erb
+++ b/app/views/admin/capacities/index.html.erb
@@ -1,0 +1,20 @@
+<div class="container p-3 p-md-4 p-lg-5">
+  <div class="my-3">
+    <h2>予約カレンダー</h2>
+  </div>
+  <div class="row">
+    <div class="col-12 mb-3">
+      <%= month_calendar events: @capacities do |date, capacities| %>
+        <%= date.day %>
+        <% capacities.each do |capacity| %>
+          <p class="text-nowrap">
+            席数 : 
+            <%= link_to edit_admin_capacity_path(capacity) do%>
+              <%= capacity.remaining_seat%>席
+            <% end%>
+          </p>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/capacities/show.html.erb
+++ b/app/views/admin/capacities/show.html.erb
@@ -1,0 +1,38 @@
+<div class="container mb-5 pt-2">
+  <div class="my-3">
+    <h2><%= l @capacity.start_time, format: :short %>予約一覧</h2>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="row">
+        <div class="col-md-12">
+          <div class="table-responsive">
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <th scope="col" class="text-nowrap">日にち</th>
+                  <th scope="col" class="text-nowrap">時間</th>
+                  <th scope="col" class="text-nowrap">名前</th>
+                  <th scope="col" class="text-nowrap">人数</th>
+                  <th scope="col" class="text-nowrap">ステータス</th>
+                  <th scope="col" class="text-nowrap"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <%= render @reservations %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="text-center mb-3">
+        <%= link_to admin_reservations_path, class: "btn btn-secondary" do %>
+          <i class="far fa-calendar-check"></i>予約一覧へ
+        <% end %>
+        <%= link_to admin_capacities_path, class: "btn btn-secondary" do %>
+          <i class="far fa-calendar-alt"></i>カレンダーへ
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -22,7 +22,7 @@
           <% end %>
         </li>
         <li class="nav-item">
-          <%= link_to admin_root_path, class: "nav-link" do %>
+          <%= link_to admin_capacities_path, class: "nav-link" do %>
             <i class="nav-icon far fa-calendar-alt"></i>
             <p>予約カレンダー</p>
           <% end %>

--- a/app/views/simple_calendar/_calendar.html.erb
+++ b/app/views/simple_calendar/_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+    <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
+    <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <%= content_tag :tr, class: calendar.tr_classes_for(week) do %>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% if defined?(Haml) && respond_to?(:block_is_haml?) && block_is_haml?(passed_block) %>
+                <% capture_haml(day, sorted_events.fetch(day, []), &passed_block) %>
+              <% else %>
+                <% passed_block.call day, sorted_events.fetch(day, []) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading text-center mb-3">
+    <%= link_to '◀︎', calendar.url_for_previous_view %>
+    <span class="calendar-title"><%= start_date.year %>年 <%= t('date.month_names')[start_date.month] %> </span>
+    <%= link_to '▶︎', calendar.url_for_next_view %>
+  </div>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr class="table-active">
+          <% date_range.slice(0, 7).each do |day| %>
+            <th><%= t('date.abbr_day_names')[day.wday] %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% date_range.each_slice(7) do |week| %>
+          <tr>
+            <% week.each do |day| %>
+              <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+                <% if defined?(Haml) && respond_to?(:block_is_haml?) && block_is_haml?(passed_block) %>
+                  <% capture_haml(day, sorted_events.fetch(day, []), &passed_block) %>
+                <% else %>
+                  <% passed_block.call day, sorted_events.fetch(day, []) %>
+                <% end %>
+              <% end %>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,0 +1,37 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+    <% if calendar.number_of_weeks == 1 %>
+      <span class="calendar-title"><%= t('simple_calendar.week', default: 'Week') %> <%= calendar.week_number %></span>
+    <% else %>
+      <span class="calendar-title"><%= t('simple_calendar.week', default: 'Week') %> <%= calendar.week_number %> - <%= calendar.end_week %></span>
+    <% end %>
+    <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% if defined?(Haml) && respond_to?(:block_is_haml?) && block_is_haml?(passed_block) %>
+                <% capture_haml(day, sorted_events.fetch(day, []), &passed_block) %>
+              <% else %>
+                <% passed_block.call day, sorted_events.fetch(day, []) %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,5 +24,6 @@ Rails.application.routes.draw do
     resources :users, only: %i[index show edit update destroy]
     resources :reservations
     patch '/reservations/cancel/:id', to: 'reservations#cancel'
+    resources :capacities, only: %i[index edit update]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,6 @@ Rails.application.routes.draw do
     resources :users, only: %i[index show edit update destroy]
     resources :reservations
     patch '/reservations/cancel/:id', to: 'reservations#cancel'
-    resources :capacities, only: %i[index edit update]
+    resources :capacities, only: %i[index show edit update]
   end
 end


### PR DESCRIPTION
## Issue 番号

Closes #12 

## 概要

- gem simple-calendarをインストール
- 日付毎のに予約数、上限人数をカレンダーで表示
- 日付毎の予約一覧を表示
- 日付毎の上限人数編集機能を実装

## 参考資料



## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
