### PR TITLE
管理画面にバリデーションエラーメッセージを追加

### DIFF
--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -17,11 +17,10 @@ class Admin::ReservationsController < Admin::BaseController
     Reservation.transaction do
       @reservation = Reservation.create!(reservation_params.merge(capacity_id: @capacity_id))
       @reservation.capacity.update!(remaining_seat: @reservation.decreased_capacity)
-      redirect_to admin_reservations_path, success: '予約が完了しました'
     end
-  rescue StandardError
-    flash.now['danger'] = "予約ができませんでした \n 今日以降の定休日以外の日付を入力してください \n 予約日の席数を確認してください"
-    render :new
+    redirect_to admin_reservations_path, success: '予約が完了しました'
+  rescue StandardError => e
+    redirect_to new_admin_reservation_path, danger: e.message
   end
 
   def edit; end

--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -15,7 +15,7 @@ class Admin::ReservationsController < Admin::BaseController
 
   def create
     Reservation.transaction do
-      @reservation = Reservation.create!(reservation_params.merge(capacity_id: capacity_id))
+      @reservation = Reservation.create!(reservation_params.merge(capacity_id: @capacity_id))
       @reservation.capacity.update!(remaining_seat: @reservation.decreased_capacity)
       redirect_to admin_reservations_path, success: '予約が完了しました'
     end

--- a/app/views/admin/capacities/_form.html.erb
+++ b/app/views/admin/capacities/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: @capacity, url: admin_capacity_path(@capacity), local: true do |f| %>
+  <%= render '/admin/shared/error_messages', object: f.object %>
   <div class="form-group">
     <%= f.label :remaining_seat %> *必須
     <%= f.number_field :remaining_seat, class: "form-control", required: true %>

--- a/app/views/admin/news/_form.html.erb
+++ b/app/views/admin/news/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: news, url: url, local: true do |f| %>
+  <%= render '/admin/shared/error_messages', object: f.object %>
   <div class="form-group">
     <%= f.label :category%>
     <%= f.select :category, News.categories_i18n.invert, {}, {class: "form-control", required: true} %>

--- a/app/views/admin/reservations/_editform.html.erb
+++ b/app/views/admin/reservations/_editform.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: @reservation, url: admin_reservation_path(@reservation), local: true do |f| %>
+  <%= render '/admin/shared/error_messages', object: f.object %>
   <div class="form-group">
     <%= f.label :name %> *必須
     <%= f.text_field :name, class: "form-control", required: true %>
@@ -11,7 +12,7 @@
     <%= f.label :phonenumber %> *必須
     <%= f.telephone_field :phonenumber, class: "form-control", required: true %>
   </div>
-    <div class="form-group">
+  <div class="form-group">
     <%= f.label :start_time %> *必須
     <%= f.date_field :capacity_id, class: "form-control", required: true %>
   </div>

--- a/app/views/admin/shared/_error_messages.html.erb
+++ b/app/views/admin/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id="error_messages" class="alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %> 

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: @user, url: admin_user_path(@user), local: true do |f| %>
+  <%= render '/admin/shared/error_messages', object: f.object %>
   <div class="form-group">
     <%= f.label :name %>
     <%= f.text_field :name, class: "form-control", required: true %>


### PR DESCRIPTION
## Issue 番号

Closes #33

## 概要

- フォーム送信時のバリデーションメッセージを表示させる
- 必要なバリデーションを追加
- バリデーションメッセージの設定

## 参考資料

マークダウン記法のリンクを用いて記載すること

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
reservationコントローラのcreateアクションではトランザクションを使用しているため、通常のバリデーションエラーメッセージが表示できなかった。
そのためフラッシュメッセージで代用。