### PR TITLE
ダッシュボードに新着の予約・お問い合わせを表示

### DIFF
--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DashboardsController < Admin::BaseController
   def index
-    @reservations = Reservation.where(created_at: 1.week.ago..Time.zone.today).order(created_at: 'desc')
-    @contacts = Contact.where(created_at: 1.week.ago..Time.zone.today).order(created_at: 'desc')
+    @reservations = Reservation.one_week
+    @contacts = Contact.one_week
   end
 end

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,5 +1,6 @@
 class Admin::DashboardsController < Admin::BaseController
   def index
     @reservations = Reservation.all.order(created_at: 'desc')
+    @contacts = Contact.all.order(created_at: 'desc')
   end
 end

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DashboardsController < Admin::BaseController
   def index
-    @reservations = Reservation.all.order(created_at: 'desc')
-    @contacts = Contact.all.order(created_at: 'desc')
+    @reservations = Reservation.where(created_at: 1.week.ago..Time.zone.today).order(created_at: 'desc')
+    @contacts = Contact.where(created_at: 1.week.ago..Time.zone.today).order(created_at: 'desc')
   end
 end

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,3 +1,5 @@
 class Admin::DashboardsController < Admin::BaseController
-  def index; end
+  def index
+    @reservations = Reservation.all.order(created_at: 'desc')
+  end
 end

--- a/app/models/concerns/recent.rb
+++ b/app/models/concerns/recent.rb
@@ -1,0 +1,8 @@
+module Recent
+  extend ActiveSupport::Concern
+
+  included do
+    scope :one_week, -> { where(created_at: 1.week.ago..Time.zone.today).order(created_at: 'desc') }
+    # 作成から一週間以内のものを降順にで取得する
+  end
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -20,4 +20,6 @@ class Contact < ApplicationRecord
     outstanding: 0,
     closed: 1
   }
+
+  include Recent
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -54,4 +54,6 @@ class Reservation < ApplicationRecord
   def increased_capacity
     capacity.remaining_seat + number_of_people
   end
+
+  include Recent
 end

--- a/app/views/admin/contacts/_contact.html.erb
+++ b/app/views/admin/contacts/_contact.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td class="text-nowrap">
-    <%= l contact.created_at, format: :short%>
+    <%= l contact.created_at, format: :long %>
   </td>
   <td class="text-nowrap">
     <%= contact.category_i18n %>

--- a/app/views/admin/dashboards/_reservation.html.erb
+++ b/app/views/admin/dashboards/_reservation.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td class="text-nowrap">
-    <%= l reservation.created_at, format: :short %>
+    <%= l reservation.created_at, format: :long %>
   </td>
   <td class="text-nowrap">
     <%= l reservation.capacity.start_time, format: :short %>

--- a/app/views/admin/dashboards/_reservation.html.erb
+++ b/app/views/admin/dashboards/_reservation.html.erb
@@ -1,0 +1,16 @@
+<tr>
+  <td class="text-nowrap">
+    <%= l reservation.created_at, format: :short %>
+  </td>
+  <td class="text-nowrap">
+    <%= l reservation.capacity.start_time, format: :short %>
+  </td>
+  <td class="text-nowrap">
+    <%= reservation.reservation_status_i18n %>
+  </td>
+  <td class="text-nowrap">
+    <%= link_to admin_reservation_path(reservation), class: "btn btn-info" do %>
+      <i class="fas fa-search-plus"></i>詳細
+    <% end%>
+  </td>
+</tr>

--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -27,4 +27,23 @@
   <div class="my-3">
     <h3>新着お問い合わせ</h3>
   </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="table-responsive">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th scope="col" class="text-nowrap">問い合わせ日時</th>
+              <th scope="col" class="text-nowrap">種類</th>
+              <th scope="col" class="text-nowrap">ステータス</th>
+              <th scope="col" class="text-nowrap"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= render @contacts %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -5,6 +5,25 @@
   <div class="my-3">
     <h3>新着予約</h3>
   </div>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="table-responsive">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th scope="col" class="text-nowrap">予約受付日</th>
+              <th scope="col" class="text-nowrap">来店日</th>
+              <th scope="col" class="text-nowrap">ステータス</th>
+              <th scope="col" class="text-nowrap"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= render partial: "reservation", collection: @reservations %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
   <div class="my-3">
     <h3>新着お問い合わせ</h3>
   </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -40,5 +40,6 @@ ja:
   time:
     formats:
       default: '%Y/%m/%d %H:%M:%S'
+      long: '%Y/%m/%d(%a)'
       short: '%Y/%m/%d'
       news: '%Y.%m.%d'


### PR DESCRIPTION
## Issue 番号

Closes #15 

## 概要

- ダッシュボードで新着の予約・お問い合わせ一覧を表示
 - 作成日時から新着順
 - 受付から一週間以内もののみ表示
 - 詳細へのリンク
 - 表示内容は簡易的に表示

## 参考資料

マークダウン記法のリンクを用いて記載すること

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
