### PR TITLE
フォーム確認画面を作成

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -8,6 +8,11 @@ class ContactsController < ApplicationController
     render :index if @contact.invalid?
   end
 
+  def back
+    @contact = Contact.new(contact_params)
+    render :index
+  end
+
   def create
     @contact = Contact.new(contact_params)
     if @contact.save

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -3,6 +3,11 @@ class ContactsController < ApplicationController
     @contact = Contact.new
   end
 
+  def confirm
+    @contact = Contact.new(contact_params)
+    render :index if @contact.invalid?
+  end
+
   def create
     @contact = Contact.new(contact_params)
     if @contact.save

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -6,10 +6,10 @@ class ReservationsController < ApplicationController
   def confirm
     capacity_id = Capacity.find_by(start_time: params[:reservation][:capacity_id]).id
     @reservation = Reservation.new(reservation_params.merge(capacity_id: capacity_id))
-    if @reservation.invalid?
-      flash.now[:danger] = 'ご来店日は日曜日、月曜日以外の日付を選択して下さい。'
-      render :index
-    end
+    return unless @reservation.invalid?
+
+    flash.now[:danger] = 'ご来店日は日曜日、月曜日以外の日付を選択して下さい。'
+    render :index
   end
 
   def back

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -3,9 +3,17 @@ class ReservationsController < ApplicationController
     @reservation = Reservation.new
   end
 
+  def confirm
+    capacity_id = Capacity.find_by(start_time: params[:reservation][:capacity_id]).id
+    @reservation = Reservation.new(reservation_params.merge(capacity_id: capacity_id))
+    if @reservation.invalid?
+      flash.now[:danger] = 'ご来店日は日曜日、月曜日以外の日付を選択して下さい。'
+      render :index
+    end
+  end
+
   def create
     Reservation.transaction do
-      capacity_id = Capacity.find_by(start_time: params[:reservation][:capacity_id]).id
       @reservation = Reservation.create!(reservation_params.merge(capacity_id: capacity_id))
       @reservation.capacity.update!(remaining_seat: @reservation.decreased_capacity)
       ReservationMailer.email(@reservation).deliver_now

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -12,6 +12,11 @@ class ReservationsController < ApplicationController
     end
   end
 
+  def back
+    @reservation = Reservation.new(reservation_params)
+    render :index
+  end
+
   def create
     Reservation.transaction do
       @reservation = Reservation.create!(reservation_params)

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -14,7 +14,7 @@ class ReservationsController < ApplicationController
 
   def create
     Reservation.transaction do
-      @reservation = Reservation.create!(reservation_params.merge(capacity_id: capacity_id))
+      @reservation = Reservation.create!(reservation_params)
       @reservation.capacity.update!(remaining_seat: @reservation.decreased_capacity)
       ReservationMailer.email(@reservation).deliver_now
       redirect_to root_path, success: 'ご予約が完了しました。'
@@ -26,6 +26,6 @@ class ReservationsController < ApplicationController
   private
 
   def reservation_params
-    params.require(:reservation).permit(:name, :email, :phonenumber, :number_of_people, :visiting_time, :reservation_status, :user_id)
+    params.require(:reservation).permit(:name, :email, :phonenumber, :number_of_people, :visiting_time, :reservation_status, :user_id, :capacity_id)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,11 @@ class UsersController < ApplicationController
     render :new if @user.invalid?
   end
 
+  def back
+    @user = User.new(user_params)
+    render :new
+  end
+
   def show; end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,6 +15,11 @@ class UsersController < ApplicationController
     end
   end
 
+  def confirm
+    @user = User.new(user_params)
+    render :new if @user.invalid?
+  end
+
   def show; end
 
   def edit

--- a/app/views/contacts/_back_form.html.erb
+++ b/app/views/contacts/_back_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_with model: @contact, method: :post, url: contacts_back_path, local: true do |f| %>
+  <%= f.hidden_field :name %>
+  <%= f.hidden_field :email %>
+  <%= f.hidden_field :phonenumber %>
+  <%= f.hidden_field :category %>
+  <%= f.hidden_field :message %>
+  <div class="actions text-center mb-3">
+    <%= f.submit "入力画面に戻る", class: "btn btn-secondary w-100" %>
+  </div>
+<% end %>

--- a/app/views/contacts/_confirm_form.html.erb
+++ b/app/views/contacts/_confirm_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_with model: @contact, local: true do |f| %>
+  <%= f.hidden_field :name %>
+  <%= f.hidden_field :email %>
+  <%= f.hidden_field :phonenumber %>
+  <%= f.hidden_field :category %>
+  <%= f.hidden_field :message %>
+  <div class="actions text-center mb-3">
+    <%= f.submit "送信する", class: "btn btn-success w-100" %>
+  </div>
+<% end %>

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @contact, url: contacts_path, local: true, id: "contact_form" do |f| %>
+<%= form_with model: @contact, url: contacts_path, method: :post, url: contacts_confirm_path, local: true, id: "contact_form" do |f| %>
   <div class="form-group">
     <div class="text-left mb-1">
       <%= f.label :name %>

--- a/app/views/contacts/confirm.html.erb
+++ b/app/views/contacts/confirm.html.erb
@@ -1,0 +1,42 @@
+<div class="container">
+  <h1 class="text-center my-5">お問い合わせ内容確認</h1>
+  <div class="row">
+    <div class="col-12 col-md-8 offset-md-2 p-3 mb-4">
+      <table class="table table-bordered bg-white">
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">お名前</th>
+          <td><%= @contact.name %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">メールアドレス</th>
+          <td><%= @contact.email %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">電話番号</th>
+          <td><%= @contact.phonenumber %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">お問い合わせ種類</th>
+          <td><%= @contact.category_i18n %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">内容</th>
+          <td><%= simple_format @contact.message %></td>
+        </tr>
+      </table>
+      <%= form_with model: @contact, local: true do |f| %>
+        <%= f.hidden_field :name %>
+        <%= f.hidden_field :email %>
+        <%= f.hidden_field :phonenumber %>
+        <%= f.hidden_field :category %>
+        <%= f.hidden_field :message %>
+        <div class="actions text-center mb-3">
+          <%= f.submit "送信する", class: "btn btn-success w-100" %>
+        </div>
+      <% end %>
+    </div>
+    <div class="col-12 text-center mb-5">
+      <%= link_to "Homeへ", root_path %>
+    </div>
+  </div>
+</div>

--- a/app/views/contacts/confirm.html.erb
+++ b/app/views/contacts/confirm.html.erb
@@ -24,26 +24,8 @@
           <td><%= simple_format @contact.message %></td>
         </tr>
       </table>
-      <%= form_with model: @contact, local: true do |f| %>
-        <%= f.hidden_field :name %>
-        <%= f.hidden_field :email %>
-        <%= f.hidden_field :phonenumber %>
-        <%= f.hidden_field :category %>
-        <%= f.hidden_field :message %>
-        <div class="actions text-center mb-3">
-          <%= f.submit "送信する", class: "btn btn-success w-100" %>
-        </div>
-      <% end %>
-      <%= form_with model: @contact, method: :post, url: contacts_back_path, local: true do |f| %>
-        <%= f.hidden_field :name %>
-        <%= f.hidden_field :email %>
-        <%= f.hidden_field :phonenumber %>
-        <%= f.hidden_field :category %>
-        <%= f.hidden_field :message %>
-        <div class="actions text-center mb-3">
-          <%= f.submit "入力画面に戻る", class: "btn btn-secondary w-100" %>
-        </div>
-      <% end %>
+      <%= render "confirm_form" %>
+      <%= render "back_form" %>
     </div>
     <div class="col-12 text-center mb-5">
       <%= link_to "Homeへ", root_path %>

--- a/app/views/contacts/confirm.html.erb
+++ b/app/views/contacts/confirm.html.erb
@@ -34,6 +34,16 @@
           <%= f.submit "送信する", class: "btn btn-success w-100" %>
         </div>
       <% end %>
+      <%= form_with model: @contact, method: :post, url: contacts_back_path, local: true do |f| %>
+        <%= f.hidden_field :name %>
+        <%= f.hidden_field :email %>
+        <%= f.hidden_field :phonenumber %>
+        <%= f.hidden_field :category %>
+        <%= f.hidden_field :message %>
+        <div class="actions text-center mb-3">
+          <%= f.submit "入力画面に戻る", class: "btn btn-secondary w-100" %>
+        </div>
+      <% end %>
     </div>
     <div class="col-12 text-center mb-5">
       <%= link_to "Homeへ", root_path %>

--- a/app/views/reservations/_back_form.html.erb
+++ b/app/views/reservations/_back_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_with model: @reservation, method: :post, url: reservations_back_path, local: true do |f| %>
+  <%= f.hidden_field :name %>
+  <%= f.hidden_field :email %>
+  <%= f.hidden_field :phonenumber %>
+  <%= f.hidden_field :capacity_id %>
+  <%= f.hidden_field :visiting_time %>
+  <%= f.hidden_field :number_of_people %>
+  <div class="actions text-center mb-3">
+    <%= f.submit "入力画面に戻る", class: "btn btn-secondary w-100" %>
+  </div>
+<% end %>

--- a/app/views/reservations/_confirm_form.html.erb
+++ b/app/views/reservations/_confirm_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_with model: @reservation, local: true, id: "reservation_form" do |f| %>
+  <%= f.hidden_field :name %>
+  <%= f.hidden_field :email %>
+  <%= f.hidden_field :phonenumber %>
+  <%= f.hidden_field :capacity_id %>
+  <%= f.hidden_field :visiting_time %>
+  <%= f.hidden_field :number_of_people %>
+  <div class="actions text-center mb-3">
+    <%= f.submit "送信", class: "btn btn-success w-100" %>
+  </div>
+<% end %>

--- a/app/views/reservations/_form.html.erb
+++ b/app/views/reservations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @reservation, url: reservations_path, local: true, id: "reservation_form" do |f| %>
+<%= form_with model: @reservation, method: :post, url: reservations_confirm_path, local: true, id: "reservation_form" do |f| %>
   <%= f.hidden_field :user_id, value: current_user&.id %>
   <div class="form-group">
     <div class="text-left mb-1">

--- a/app/views/reservations/confirm.html.erb
+++ b/app/views/reservations/confirm.html.erb
@@ -1,0 +1,47 @@
+<div class="container">
+  <h1 class="text-center my-5">ご予約内容確認</h1>
+  <div class="row">
+    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <table class="table table-bordered bg-white">
+        <tr>
+          <th scope="row"  class="table-active text-center align-middle">お名前</th>
+          <td><%= @reservation.name %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">メールアドレス</th>
+          <td><%= @reservation.email %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">電話番号</th>
+          <td><%= @reservation.phonenumber %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">ご来店日</th>
+          <td><%= l @reservation.capacity.start_time, format: :long %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">ご来店時間</th>
+          <td><%= @reservation.visiting_time_i18n %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">人数</th>
+          <td><%= @reservation.number_of_people %></td>
+        </tr>
+      </table>
+      <%= form_with model: @reservation, local: true, id: "reservation_form" do |f| %>
+        <%= f.hidden_field :name %>
+        <%= f.hidden_field :email %>
+        <%= f.hidden_field :phonenumber %>
+        <%= f.hidden_field :capacity_id %>
+        <%= f.hidden_field :visiting_time %>
+        <%= f.hidden_field :number_of_people %>
+        <div class="actions text-center mb-3">
+          <%= f.submit "送信", class: "btn btn-success w-100" %>
+        </div>
+      <% end %>
+      <div class="text-center mb-5">
+        <%= link_to "Homeへ", root_path %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/reservations/confirm.html.erb
+++ b/app/views/reservations/confirm.html.erb
@@ -28,28 +28,8 @@
           <td><%= @reservation.number_of_people %></td>
         </tr>
       </table>
-      <%= form_with model: @reservation, local: true, id: "reservation_form" do |f| %>
-        <%= f.hidden_field :name %>
-        <%= f.hidden_field :email %>
-        <%= f.hidden_field :phonenumber %>
-        <%= f.hidden_field :capacity_id %>
-        <%= f.hidden_field :visiting_time %>
-        <%= f.hidden_field :number_of_people %>
-        <div class="actions text-center mb-3">
-          <%= f.submit "送信", class: "btn btn-success w-100" %>
-        </div>
-      <% end %>
-      <%= form_with model: @reservation, method: :post, url: reservations_back_path, local: true do |f| %>
-        <%= f.hidden_field :name %>
-        <%= f.hidden_field :email %>
-        <%= f.hidden_field :phonenumber %>
-        <%= f.hidden_field :capacity_id %>
-        <%= f.hidden_field :visiting_time %>
-        <%= f.hidden_field :number_of_people %>
-      <div class="actions text-center mb-3">
-        <%= f.submit "入力画面に戻る", class: "btn btn-secondary w-100" %>
-      </div>
-    <% end %>
+      <%= render "confirm_form" %>
+      <%= render "back_form" %>
       <div class="text-center mb-5">
         <%= link_to "Homeへ", root_path %>
       </div>

--- a/app/views/reservations/confirm.html.erb
+++ b/app/views/reservations/confirm.html.erb
@@ -39,6 +39,17 @@
           <%= f.submit "送信", class: "btn btn-success w-100" %>
         </div>
       <% end %>
+      <%= form_with model: @reservation, method: :post, url: reservations_back_path, local: true do |f| %>
+        <%= f.hidden_field :name %>
+        <%= f.hidden_field :email %>
+        <%= f.hidden_field :phonenumber %>
+        <%= f.hidden_field :capacity_id %>
+        <%= f.hidden_field :visiting_time %>
+        <%= f.hidden_field :number_of_people %>
+      <div class="actions text-center mb-3">
+        <%= f.submit "入力画面に戻る", class: "btn btn-secondary w-100" %>
+      </div>
+    <% end %>
       <div class="text-center mb-5">
         <%= link_to "Homeへ", root_path %>
       </div>

--- a/app/views/users/_back_form.html.erb
+++ b/app/views/users/_back_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_with model: @user, url: users_back_path, local: true do |f| %>
+  <%= f.hidden_field :name %>
+  <%= f.hidden_field :email %>
+  <%= f.hidden_field :phonenumber %>
+  <div class="actions text-center mb-5">
+    <%= f.submit "入力画面に戻る", class: "btn btn-secondary w-100" %>
+  </div>
+<% end %>

--- a/app/views/users/_confirm_form.html.erb
+++ b/app/views/users/_confirm_form.html.erb
@@ -1,0 +1,10 @@
+<%= form_with model: @user, local: true do |f| %>
+  <%= f.hidden_field :name %>
+  <%= f.hidden_field :email %>
+  <%= f.hidden_field :phonenumber %>
+  <%= f.hidden_field :password %>
+  <%= f.hidden_field :password_confirmation %>
+  <div class="actions text-center my-2">
+    <%= f.submit "登録する", class: "btn btn-success w-100" %>
+  </div>
+<% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @user, url: users_path, local: true, id: "user_form" do |f| %>
+<%= form_with model: @user, method: :post, url: users_confirm_path, local: true, id: "user_form" do |f| %>
   <div class="form-group">
     <div class="text-left mb-1">
       <%= f.label :name %>

--- a/app/views/users/confirm.html.erb
+++ b/app/views/users/confirm.html.erb
@@ -26,6 +26,14 @@
           <%= f.submit "登録する", class: "btn btn-success w-100" %>
         </div>
       <% end %>
+      <%= form_with model: @user, method: :post, url: users_back_path, local: true do |f| %>
+        <%= f.hidden_field :name %>
+        <%= f.hidden_field :email %>
+        <%= f.hidden_field :phonenumber %>
+        <div class="actions text-center mb-3">
+          <%= f.submit "入力画面に戻る", class: "btn btn-secondary w-50" %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/users/confirm.html.erb
+++ b/app/views/users/confirm.html.erb
@@ -31,7 +31,7 @@
         <%= f.hidden_field :email %>
         <%= f.hidden_field :phonenumber %>
         <div class="actions text-center mb-3">
-          <%= f.submit "入力画面に戻る", class: "btn btn-secondary w-50" %>
+          <%= f.submit "入力画面に戻る", class: "btn btn-secondary w-100" %>
         </div>
       <% end %>
     </div>

--- a/app/views/users/confirm.html.erb
+++ b/app/views/users/confirm.html.erb
@@ -1,0 +1,31 @@
+<div class="container user-margin">
+  <h2 class="text-center my-5">会員登録内容確認</h2>
+  <div class="row">
+    <div class="col-12 col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <table class="table table-bordered bg-white">
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">お名前</th>
+          <td><%= @user.name %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">メールアドレス</th>
+          <td><%= @user.email %></td>
+        </tr>
+        <tr>
+          <th scope="row" class="table-active text-center align-middle">電話番号</th>
+          <td><%= @user.phonenumber %></td>
+        </tr>
+      </table>
+      <%= form_with model: @user, local: true do |f| %>
+        <%= f.hidden_field :name %>
+        <%= f.hidden_field :email %>
+        <%= f.hidden_field :phonenumber %>
+        <%= f.hidden_field :password %>
+        <%= f.hidden_field :password_confirmation %>
+        <div class="actions text-center my-2">
+          <%= f.submit "登録する", class: "btn btn-success w-100" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/users/confirm.html.erb
+++ b/app/views/users/confirm.html.erb
@@ -16,24 +16,8 @@
           <td><%= @user.phonenumber %></td>
         </tr>
       </table>
-      <%= form_with model: @user, local: true do |f| %>
-        <%= f.hidden_field :name %>
-        <%= f.hidden_field :email %>
-        <%= f.hidden_field :phonenumber %>
-        <%= f.hidden_field :password %>
-        <%= f.hidden_field :password_confirmation %>
-        <div class="actions text-center my-2">
-          <%= f.submit "登録する", class: "btn btn-success w-100" %>
-        </div>
-      <% end %>
-      <%= form_with model: @user, method: :post, url: users_back_path, local: true do |f| %>
-        <%= f.hidden_field :name %>
-        <%= f.hidden_field :email %>
-        <%= f.hidden_field :phonenumber %>
-        <div class="actions text-center mb-3">
-          <%= f.submit "入力画面に戻る", class: "btn btn-secondary w-100" %>
-        </div>
-      <% end %>
+      <%= render "confirm_form" %>
+      <%= render "back_form" %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
 
   resources :reservations, only: %i[index create]
   resources :contacts, only: %i[index create]
+  post 'contacts/confirm'
+  post 'contacts/back'
 
   resources :users, only: %i[new create]
   get '/mypage', to: 'users#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   get 'shop', to: 'static_pages#shop'
 
   resources :reservations, only: %i[index create]
+  post 'reservations/confirm'
+  post 'reservations/back'
+
   resources :contacts, only: %i[index create]
   post 'contacts/confirm'
   post 'contacts/back'
@@ -19,6 +22,7 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
   resources :password_resets, only: %i[new create edit update]
+
   resources :news, only: %i[index show]
   resources :menus, only: %i[index]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   get '/mypage', to: 'users#show'
   get '/mypage/edit', to: 'users#edit'
   patch '/mypage/edit', to: 'users#update'
+  post 'users/confirm'
+  post 'users/back'
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'


### PR DESCRIPTION
## Issue 番号

Closes #16 

## 概要

- 会員登録送信時の確認画面を追加
- 会員登録確認画面からフォームに戻るアクションを追加
- お問い合わせ送信時の確認画面を追加
-  お問い合わせ確認画面からフォームに戻るアクションを追加
- 予約送信時の確認画面を追加
- 予約確認画面からフォームに戻るアクションを追加

- 確認、戻るに対応できるようにコントローラーの修正


## 参考資料

マークダウン記法のリンクを用いて記載すること

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
