### PR TITLE
FIX:メイラーの本番環境設定

### DIFF
--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -6,8 +6,8 @@ if Rails.env.production?
   ActionMailer::Base.smtp_settings = {
     port: 587,
     address: 'smtp.gmail.com',
-    # user_name: Rails.application.credentials.gmail[:address],
-    # password: Rails.application.credentials.gmail[:password],
+    user_name: Rails.application.credentials.gmail[:address],
+    password: Rails.application.credentials.gmail[:password],
     domain: host,
     authentication: 'plain'
   }


### PR DESCRIPTION
## Issue 番号

## 概要

メイラーの本番環境設定のコメントアウトを削除し本番環境の設定を行う。
- `master.key` を Heroku の環境変数に追加

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行
