### PR TITLE
ダッシュボードに新着予約が表示されないエラーを修正

### DIFF
--- a/app/models/concerns/recent.rb
+++ b/app/models/concerns/recent.rb
@@ -2,7 +2,7 @@ module Recent
   extend ActiveSupport::Concern
 
   included do
-    scope :one_week, -> { where(created_at: 1.week.ago..Time.zone.today).order(created_at: 'desc') }
+    scope :one_week, -> { where(created_at: 1.week.ago..Time.zone.now).order(created_at: 'desc') }
     # 作成から一週間以内のものを降順にで取得する
   end
 end


### PR DESCRIPTION
## Issue 番号

Closes #86

## 概要
ダッシュボードに新着予約が表示されないエラーを修正
新着を判定するメソッドを
```
 where(created_at: 1.week.ago..Time.zone.now).order(created_at: 'desc')
```
に修正

## 参考資料

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
