### PR TITLE
デプロイエラー修正

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -67,7 +67,7 @@ module.exports = function (api) {
           async: false,
         },
       ],
-      ['@babel/plugin-proposal-private-methods', { loose: true }],
+      ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
     ].filter(Boolean),
   };
 };


### PR DESCRIPTION
## 概要

Herokuデプロイ時にエラー
```
Compilation failed:
       Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
```
babel.config.jsを修正

## 参考資料

https://prograshi.com/framework/rails/babel-compile-alert/
