### PR TITLE
Application errorを修正

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -11,8 +11,8 @@ amazon:
   service: S3
   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-  region: Rails.application.credentials.dig(:aws, :region)
-  bucket: Rails.application.credentials.dig(:aws, :bucket)
+  region: <%= Rails.application.credentials.dig(:aws, :region) %>
+  bucket: <%= Rails.application.credentials.dig(:aws, :bucket) %>
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS


### PR DESCRIPTION
## 概要

Herokuのデプロイ時アプリケーションエラーとなったため確認
credentialsが正しく呼び出せていなかったため修正

## 参考資料

マークダウン記法のリンクを用いて記載すること

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
