### PR TITLE
SNSシェアボタンを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'slack-notifier'
 gem 'gretel'
 gem 'fog-aws'
 gem 'aws-sdk-s3', require: false
+gem 'social-share-button'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,13 @@ GEM
       ssrf_filter (~> 1.0)
     childprocess (3.0.0)
     coderay (1.1.3)
+    coffee-rails (5.0.0)
+      coffee-script (>= 2.2.0)
+      railties (>= 5.2.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     debug_inspector (1.1.0)
@@ -116,6 +123,7 @@ GEM
       activesupport (>= 3.0.0)
     erubi (1.10.0)
     excon (0.91.0)
+    execjs (2.8.1)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -341,6 +349,8 @@ GEM
     simple_calendar (2.4.3)
       rails (>= 3.0)
     slack-notifier (2.4.0)
+    social-share-button (1.2.4)
+      coffee-rails
     sorcery (0.16.1)
       bcrypt (~> 3.1)
       oauth (~> 0.5, >= 0.5.5)
@@ -422,6 +432,7 @@ DEPENDENCIES
   sass-rails (>= 6)
   simple_calendar
   slack-notifier
+  social-share-button
   sorcery
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,6 +25,8 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 @import 'slick-theme';
 @import 'slick';
 
+@import 'social-share-button';
+
 @import url('https://fonts.googleapis.com/css2?family=Shippori+Mincho:wght@500&family=WindSong:wght@500&display=swap');
 
 // 全体

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,6 +6,7 @@ require('jquery');
 require('slick.js');
 require('jquery.validate.js');
 require('jquery.validate.form.js');
+require('social-share-button');
 
 import 'src/application';
 import 'bootstrap/dist/js/bootstrap';

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -19,7 +19,9 @@
         <div class="body m-5">
           <p><%= @news.body %></p>
         </div>
-        <%= social_share_button_tag(@news.title) %>
+        <div class="text-right mr-5 mb-5">
+          <%= social_share_button_tag(@news.title) %>
+        </div>
       </div>
       <%= render "arrows" %>
     </div>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -19,6 +19,7 @@
         <div class="body m-5">
           <p><%= @news.body %></p>
         </div>
+        <%= social_share_button_tag(@news.title) %>
       </div>
       <%= render "arrows" %>
     </div>

--- a/config/initializers/social_share_button.rb
+++ b/config/initializers/social_share_button.rb
@@ -1,0 +1,5 @@
+SocialShareButton.configure do |config|
+  config.allow_sites = %w(twitter facebook weibo qq douban google_bookmark
+                          delicious tumblr pinterest email linkedin wechat vkontakte
+                          xing reddit hacker_news telegram odnoklassniki whatsapp_app whatsapp_web)
+end

--- a/config/initializers/social_share_button.rb
+++ b/config/initializers/social_share_button.rb
@@ -1,5 +1,4 @@
 SocialShareButton.configure do |config|
-  config.allow_sites = %w(twitter facebook weibo qq douban google_bookmark
-                          delicious tumblr pinterest email linkedin wechat vkontakte
-                          xing reddit hacker_news telegram odnoklassniki whatsapp_app whatsapp_web)
+  config.allow_sites = %w[twitter facebook google_bookmark
+                          pinterest]
 end


### PR DESCRIPTION
## Issue 番号

Closes #108

## 概要

Newsの投稿にSNSシェアボタンを追加
- `gem 'social-share-button'`を使用
- `Twitter`, `Facebook`,`Pinterest`にシェアできるようにする

## 参考資料


## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
