### PR TITLE
デプロイエラー修正

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,7 +6,6 @@ require('jquery');
 require('slick.js');
 require('jquery.validate.js');
 require('jquery.validate.form.js');
-require('social-share-button');
 
 import 'src/application';
 import 'bootstrap/dist/js/bootstrap';


### PR DESCRIPTION

## 概要

herokuエラー
```
ModuleNotFoundError: Module not found: Error: Can't resolve 'social-share-button' in '/tmp/build_ae4fd6af/app/javascript/packs'
```

## 参考資料

マークダウン記法のリンクを用いて記載すること

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
