### PR TITLE
UI修正

### DIFF
--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -13,7 +13,7 @@
           <%= l @news.created_at, format: :news %>
           <%= link_to @news.category_i18n, news_index_path(category: @news.category), class:"btn btn-outline-success btn-sm rounded-pill text-nowrap ml-auto" %>
         </div>
-        <div class="mx-5 mb-5">
+        <div class="mx-1 mx-md-3 mx-lg-5 mb-1 mb-md-3 mb-lg-5">
           <%= image_tag @news.news_image.url, class: "card-img-top img-fluid rounded mt-3" %>
         </div>
         <div class="body m-5">

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -27,7 +27,7 @@
     </div>
     <div class="col-lg-4 mx-3 mx-lg-0">
       <h5 class="mt-5 mb-3">最新のお知らせ</h5>
-      <div class="shadow-lg mb-3">
+      <div class="shadow mb-3">
         <%= render @latest_news %>
       </div>
     </div>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -9,7 +9,7 @@
     <div class="col-lg-8">
       <div class="card bg-white my-4 p-2 shadow">
         <h4 class="m-1 m-md-3 m-lg-5"><%= @news.title %></h4>
-        <div class="d-flex justify-content-between align-items-center text-muted mx-5">
+        <div class="d-flex justify-content-between align-items-center text-muted mx-1 mx-md-3 mx-lg-5">
           <%= l @news.created_at, format: :news %>
           <%= link_to @news.category_i18n, news_index_path(category: @news.category), class:"btn btn-outline-success btn-sm rounded-pill text-nowrap ml-auto" %>
         </div>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="col-lg-8">
       <div class="card bg-white my-4 p-2 shadow">
-        <h2 class="m-5"><%= @news.title %></h2>
+        <h4 class="m-1 m-md-3 m-lg-5"><%= @news.title %></h4>
         <div class="d-flex justify-content-between align-items-center text-muted mx-5">
           <%= l @news.created_at, format: :news %>
           <%= link_to @news.category_i18n, news_index_path(category: @news.category), class:"btn btn-outline-success btn-sm rounded-pill text-nowrap ml-auto" %>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -16,7 +16,7 @@
         <div class="mx-1 mx-md-3 mx-lg-5 mb-1 mb-md-3 mb-lg-5">
           <%= image_tag @news.news_image.url, class: "card-img-top img-fluid rounded mt-3" %>
         </div>
-        <div class="body m-5">
+        <div class="body m-1 m-md-3 m-lg-5">
           <p><%= @news.body %></p>
         </div>
         <div class="text-right mr-5 mb-5">


### PR DESCRIPTION
## Issue 番号

Closes #114 

## 概要

News詳細画面のレスポンシブ時の余白、文字サイズを調整

## 参考資料


## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
必要があれば再度調整
