### PR TITLE
予約ステータス変更修正

### DIFF
--- a/app/controllers/admin/reservations_controller.rb
+++ b/app/controllers/admin/reservations_controller.rb
@@ -1,5 +1,5 @@
 class Admin::ReservationsController < Admin::BaseController
-  before_action :set_reservation, only: %i[show edit update destroy cancel]
+  before_action :set_reservation, only: %i[show edit update destroy cancel status_update]
   before_action :assign_to_capacity_id, only: %i[create update]
 
   def index
@@ -35,6 +35,15 @@ class Admin::ReservationsController < Admin::BaseController
   rescue StandardError
     flash.now['danger'] = '予約の変更ができませんでした'
     render :edit
+  end
+
+  def status_update
+    if @reservation.update!(reservation_params)
+      redirect_to admin_reservations_path, success: '変更が完了しました'
+    else
+      flash.now['danger'] = '更新に失敗しました'
+      render :show
+    end
   end
 
   def destroy

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -13,7 +13,7 @@ class Reservation < ApplicationRecord
   validates :reservation_status, presence: true
   validates :capacity_id, presence: true
 
-  validate :date_before_today
+  validate :date_before_today, on: :create
   validate :start_time_not_sunday
   validate :start_time_not_monday
 

--- a/app/views/admin/reservations/_status_form.html.erb
+++ b/app/views/admin/reservations/_status_form.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-12 mb-3">
-    <%= form_with model:@reservation, url: admin_reservation_path(@reservation), local: true  do |f| %>
+    <%= form_with model:@reservation, url: admin_status_path(@reservation), local: true  do |f| %>
       <div class="row">
         <div class="form-inline align-items-right mx-auto">
           <div class="col-auto">

--- a/app/views/admin/reservations/_status_form.html.erb
+++ b/app/views/admin/reservations/_status_form.html.erb
@@ -1,0 +1,16 @@
+<div class="row">
+  <div class="col-12 mb-3">
+    <%= form_with model:@reservation, url: admin_reservation_path(@reservation), local: true  do |f| %>
+      <div class="row">
+        <div class="form-inline align-items-right mx-auto">
+          <div class="col-auto">
+            <%= f.select :reservation_status, Reservation.reservation_statuses_i18n.invert, {}, {class: "form-control", required: true} %>
+          </div>
+          <div class="col-auto">
+            <%= f.submit "更新",  class: "btn btn-primary" %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/reservations/show.html.erb
+++ b/app/views/admin/reservations/show.html.erb
@@ -4,6 +4,7 @@
       <div class="my-3">
         <h2>予約詳細</h2>
       </div>
+      <%= render "status_form" %>
       <div class="text-right mb-3">
         <%= link_to edit_admin_reservation_path(@reservation), class: "btn btn-success" do %>
           <i class="far fa-edit"></i>予約変更

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     resources :reservations
     resources :contacts, only: %i[index show update destroy]
     patch '/reservations/cancel/:id', to: 'reservations#cancel'
+    patch '/reservations/status/:id', to: 'reservations#status_update', as: :status
     resources :capacities, only: %i[index show edit update]
   end
 


### PR DESCRIPTION
## Issue 番号

Closes #115 

## 概要

予約ステータスを変更機能を改善
- 予約ステータスを管理画面の詳細から変更可能
- 過去の日付でも編集可能

## 参考資料

https://railsguides.jp/active_record_validations.html

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
