### PR TITLE
ゲストユーザーの編集機能を制限

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :require_login, only: %i[show edit update]
+  before_action :ensure_normal_user, only: %i[update]
 
   def new
     @user = User.new
@@ -42,6 +43,12 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def ensure_normal_user
+    return unless current_user.email == User::GUEST_USER
+
+    redirect_to mypage_path, danger: 'ゲストユーザーは編集できません。'
+  end
 
   def user_params
     params.require(:user).permit(:name, :email, :phonenumber, :password, :password_confirmation)


### PR DESCRIPTION
## Issue 番号

Closes #124 

## 概要

マイページでのゲストユーザーの編集機能を制限

## 参考資料

マークダウン記法のリンクを用いて記載すること

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
