### PR TITLE
休業日設定アクションの追加

### DIFF
--- a/app/controllers/admin/capacities_controller.rb
+++ b/app/controllers/admin/capacities_controller.rb
@@ -1,5 +1,5 @@
 class Admin::CapacitiesController < Admin::BaseController
-  before_action :set_capacity, only: %i[show edit update]
+  before_action :set_capacity, only: %i[show edit update closed]
 
   def index
     @capacities = Capacity.all
@@ -21,10 +21,10 @@ class Admin::CapacitiesController < Admin::BaseController
   end
 
   def closed
-    if @capacity.update!(capacity_params, remaining_seat: 0)
-      redirect_to admin_capacities_path, success: '完了しました'
+    if @capacity.update!(remaining_seat: 0)
+      redirect_to admin_capacities_path, success: '休業日に設定しました'
     else
-      flash.now[:danger] = 'できませんでした'
+      flash.now[:danger] = '休業日に設定できませんでした'
       render :index
     end
   end

--- a/app/controllers/admin/capacities_controller.rb
+++ b/app/controllers/admin/capacities_controller.rb
@@ -20,6 +20,15 @@ class Admin::CapacitiesController < Admin::BaseController
     end
   end
 
+  def closed
+    if @capacity.update!(capacity_params, remaining_seat: 0)
+      redirect_to admin_capacities_path, success: '完了しました'
+    else
+      flash.now[:danger] = 'できませんでした'
+      render :index
+    end
+  end
+
   private
 
   def set_capacity

--- a/app/views/admin/capacities/_closed.html.erb
+++ b/app/views/admin/capacities/_closed.html.erb
@@ -1,0 +1,17 @@
+<div class="row">
+  <div class="col-12 mb-3">
+    <%= form_with model:@reservation, url: admin_closed_path(@capacity), local: true  do |f| %>
+      <div class="row">
+        <div class="form-inline align-items-right mx-auto">
+          <div class="col-auto">
+            <%= f.label :start_time %>
+            <%= f.date_field :start_time, class: "form-control", required: true %>
+          </div>
+          <div class="col-auto">
+            <%= f.submit "更新",  class: "btn btn-primary" %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/capacities/_closed.html.erb
+++ b/app/views/admin/capacities/_closed.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-12 mb-3">
-    <%= form_with model:@reservation, url: admin_closed_path(@capacity), local: true  do |f| %>
+    <%= form_with model:@capacity, url: admin_closed_path, local: true  do |f| %>
       <div class="row">
         <div class="form-inline align-items-right mx-auto">
           <div class="col-auto">

--- a/app/views/admin/capacities/index.html.erb
+++ b/app/views/admin/capacities/index.html.erb
@@ -19,7 +19,7 @@
             <% end%>
           </p>
           <p class="text-nowrap">
-            <%= link_to admin_closed_path(capacity), method: :patch, data: {confirm: "休業日に設定してもよろしいですか?"} do%>
+            <%= link_to admin_closed_path(capacity), method: :patch, data: {confirm: "休業日に設定してもよろしいですか?"}, class: "btn btn-success btn-sm" do%>
               休業日に設定
             <% end%>
           </p>

--- a/app/views/admin/capacities/index.html.erb
+++ b/app/views/admin/capacities/index.html.erb
@@ -19,8 +19,8 @@
             <% end%>
           </p>
           <p class="text-nowrap">
-            <%= link_to admin_closed_path(capacity), method: :patch do%>
-              休業
+            <%= link_to admin_closed_path(capacity), method: :patch, data: {confirm: "休業日に設定してもよろしいですか?"} do%>
+              休業日に設定
             <% end%>
           </p>
         <% end %>

--- a/app/views/admin/capacities/index.html.erb
+++ b/app/views/admin/capacities/index.html.erb
@@ -18,6 +18,11 @@
               <%= capacity.reservations.count%>件
             <% end%>
           </p>
+          <p class="text-nowrap">
+            <%= link_to admin_closed_path(capacity), method: :patch do%>
+              休業
+            <% end%>
+          </p>
         <% end %>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,10 +36,11 @@ Rails.application.routes.draw do
     resources :menus
     resources :users, only: %i[index show edit update destroy]
     resources :reservations
-    resources :contacts, only: %i[index show update destroy]
     patch '/reservations/cancel/:id', to: 'reservations#cancel', as: :cancel
     patch '/reservations/status/:id', to: 'reservations#status_update', as: :status
+    resources :contacts, only: %i[index show update destroy]
     resources :capacities, only: %i[index show edit update]
+    patch '/capacities/closed/:id', to: 'capacities#closed', as: :closed
   end
 
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development?


### PR DESCRIPTION
## Issue 番号

Closes #120 

## 概要

ワンクリックで指定日が予約できないように管理画面にボタンを設置
- カレンダーの指定日をクリックでcapacityが0になり予約不可となる。

## 参考資料

マークダウン記法のリンクを用いて記載すること

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
使いにくい？
動的にバリデーションを設定できる方が良い？
様子見で要改善


