### PR TITLE
予約リマインダーを設定

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -88,6 +88,9 @@ class Reservation < ApplicationRecord
   # 今日の予約かつステータスが来店予約のデータを取得する
   scope :today_reservation, -> { where(reservation_status: 'visiting', capacity_id: Capacity.today_id) }
 
+  # 今日の予約件数を習得する
+  scope :count_today_reservation, -> { where(capacity_id: Capacity.today_id).count }
+
   # 作成から一週間以内のものを降順にで取得するscopeを呼び出す
   include Recent
 end

--- a/lib/tasks/reservation_remind.rake
+++ b/lib/tasks/reservation_remind.rake
@@ -1,2 +1,13 @@
 namespace :reservation_remind do
+  desc '本日の予約がある場合、予約件数をSlackに通知する'
+  task today_reservation_to_slack: :environment do
+    @capacity_id = Capacity.find_by(start_time: Time.zone.today).id
+    @reservation = Reservation.where(capacity_id: @capacity_id).count
+    notifier = Slack::Notifier.new(
+      Rails.application.credentials.slack[:notifier],
+      channel: '#予約通知',
+      username: '予約通知くん'
+    )
+    notifier.ping("本日の予約は#{@reservation}件です") if @reservation.positive?
+  end
 end

--- a/lib/tasks/reservation_remind.rake
+++ b/lib/tasks/reservation_remind.rake
@@ -1,12 +1,11 @@
 namespace :reservation_remind do
   desc '本日の予約がある場合、予約件数をSlackに通知する'
   task today_reservation_to_slack: :environment do
-    @reservation = Reservation.count_today_reservation
     notifier = Slack::Notifier.new(
       Rails.application.credentials.slack[:notifier],
       channel: '#予約通知',
       username: '予約通知くん'
     )
-    notifier.ping("本日の予約は#{@reservation}件です") if @reservation.positive?
+    notifier.ping("本日の予約は#{Reservation.count_today_reservation}件です") if Reservation.count_today_reservation.positive?
   end
 end

--- a/lib/tasks/reservation_remind.rake
+++ b/lib/tasks/reservation_remind.rake
@@ -1,8 +1,7 @@
 namespace :reservation_remind do
   desc '本日の予約がある場合、予約件数をSlackに通知する'
   task today_reservation_to_slack: :environment do
-    @capacity_id = Capacity.find_by(start_time: Time.zone.today).id
-    @reservation = Reservation.where(capacity_id: @capacity_id).count
+    @reservation = Reservation.count_today_reservation
     notifier = Slack::Notifier.new(
       Rails.application.credentials.slack[:notifier],
       channel: '#予約通知',

--- a/lib/tasks/reservation_remind.rake
+++ b/lib/tasks/reservation_remind.rake
@@ -1,0 +1,2 @@
+namespace :reservation_remind do
+end


### PR DESCRIPTION
## Issue 番号

Closes #140

## 概要

予約がある日に何件予約があるかSlackに通知するリマインダー機能を追加
- 予約がある日に何件予約があるかSlackに通知するRakeタスクを設定
- Herokuで定期実行の設定(Heroku Scheduler)

## 参考資料


## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
