### PR TITLE
メニューの画像をポップアップにする

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,9 @@
     <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"/>
     <script type="text/javascript" src="//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.min.js"></script>
     <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" type="text/javascript"></script>
   </head>
   <body>
     <header>

--- a/app/views/menus/_menu.html.erb
+++ b/app/views/menus/_menu.html.erb
@@ -1,6 +1,8 @@
 <div class="col-6 col-md-3">
   <div class="card border-0 bg-transparent">
-    <%= image_tag menu.menu_image.url, class: "card-img-top img-fluid rounded" %>
+    <%= link_to menu.menu_image.url, "data-lightbox": menu.menu_image.url do %>
+      <%= image_tag menu.menu_image.url, class: "card-img-top img-fluid rounded" %>
+    <% end %>
     <div class="menu-body">
       <h5 class="menu-title card-title text-center"><%=simple_format menu.name%></h5>
       <div class="menu-explain card-text"><%=simple_format menu.content%></div>


### PR DESCRIPTION
## Issue 番号

Closes #141 

## 概要

メニューの投稿されている画像をクリックで拡大ポップアップとなるようにする。
lightbox2を使用

## 参考資料

https://qiita.com/weeksmtwtfs737/items/a814c305764b2d664e88

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
