### PR TITLE
メニューの画像をポップアップ

### DIFF
--- a/app/views/menus/_menu.html.erb
+++ b/app/views/menus/_menu.html.erb
@@ -1,6 +1,8 @@
 <div class="col-6 col-md-3">
   <div class="card border-0 bg-transparent">
-    <%= image_tag menu.menu_image.url, class: "card-img-top img-fluid rounded" %>
+    <%= link_to menu.menu_image.url, "data-lightbox": menu.menu_image.url do %>
+      <%= image_tag menu.menu_image.url, class: "card-img-top img-fluid rounded" %>
+    <% end %>
     <div class="menu-body">
       <h5 class="menu-title card-title text-center"><%=simple_format menu.name%></h5>
       <div class="menu-explain card-text"><%=simple_format menu.content%></div>

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -87,3 +87,6 @@
   </div>
 <% end %>
 </div>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/css/lightbox.css" rel="stylesheet">
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lightbox2/2.7.1/js/lightbox.min.js" type="text/javascript"></script>


### PR DESCRIPTION
## Issue 番号

Closes #141 

## 概要

メニューの投稿されている画像をクリックで拡大ポップアップとなるようにする。
lightbox2を使用

## 参考資料

https://qiita.com/weeksmtwtfs737/items/a814c305764b2d664e88

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
他により良い技術があれば検討し採用する。