### PR TITLE
Feature/dashboard today

### DIFF
--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -100,6 +100,12 @@ class Reservation < ApplicationRecord
   # capacityを降順
   scope :capacity_desc, -> { search_capacity.date_desc }
 
+  # 今日の予約かつステータスが来店予約のデータを取得する
+  scope :today_reservation, -> { where(reservation_status: 'visiting', capacity_id: Capacity.today_id) }
+
+  # 今日の予約かつステータスが来店予約のデータの件数を習得する
+  scope :count_today_reservation, -> { today_reservation.count }
+
   # 作成から一週間以内のものを降順にで取得するscopeを呼び出す
   include Recent
 end

--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -3,11 +3,15 @@
     <h1>管理画面</h1>
   </div>
   <div class="my-5">
-    <h3>本日の予約 : 
-      <%= link_to "/admin/capacities/#{Capacity.today_id}" do%>
-        <%= Reservation.count_today_reservation %>件
-      <% end %>
-    </h3>
+    <% if Reservation.count_today_reservation.positive? %>
+      <h3>本日の予約 : 
+        <%= link_to "/admin/capacities/#{Capacity.today_id}" do%>
+          <%= Reservation.count_today_reservation %>件
+        <% end %>
+      </h3>
+    <% else %>
+      <h3>本日の予約はありません</h3>
+    <% end %>
   </div>
   <div class="my-3">
     <h3>新着予約</h3>

--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -3,7 +3,11 @@
     <h1>管理画面</h1>
   </div>
   <div class="my-5">
-    <h3>本日の予約は<%= Reservation.count_today_reservation %>件です</h3>
+    <h3>本日の予約 : 
+      <%= link_to "/admin/capacities/#{Capacity.today_id}" do%>
+        <%= Reservation.count_today_reservation %>件
+      <% end %>
+    </h3>
   </div>
   <div class="my-3">
     <h3>新着予約</h3>

--- a/app/views/admin/dashboards/index.html.erb
+++ b/app/views/admin/dashboards/index.html.erb
@@ -2,6 +2,9 @@
   <div class="mb-3 text-center">
     <h1>管理画面</h1>
   </div>
+  <div class="my-5">
+    <h3>本日の予約は<%= Reservation.count_today_reservation %>件です</h3>
+  </div>
   <div class="my-3">
     <h3>新着予約</h3>
   </div>


### PR DESCRIPTION
## Issue 番号

Closes #143

## 概要

管理画面ダッシュボードに本日の予約件数を表示
- 本日かつステータスが「来店予約」のみカウントする
- その日の予約一覧へのリンクを作成
- 予約があるなしで表示を変える
## 参考資料



## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
- [ ] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
