### PR TITLE
エラーのSlack通知を本番環境のみに設定

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,6 +1,9 @@
 require 'exception_notification/rails'
 
 ExceptionNotification.configure do |config|
+  config.ignore_if do
+    !Rails.env.production?
+  end
   config.add_notifier :slack,
                       webhook_url: Rails.application.credentials.slack[:notifier],
                       channel: '#エラー' # 通知したいチャンネル名


### PR DESCRIPTION
## Issue 番号

Closes #145 

## 概要
エラー通知を本番環境のみに設定

## 参考資料

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `bundle exec rubocop -a` を実行

## スクリーンショット（必要があれば）

## 備考
